### PR TITLE
Fixes a number of issues when the gist object is not present

### DIFF
--- a/src/managers/message-manager.js
+++ b/src/managers/message-manager.js
@@ -78,8 +78,9 @@ export function hideMessage(instanceId) {
 
 export function removePersistentMessage(instanceId) {
   var message = fetchMessageByInstanceId(instanceId);
+  var messageProperties = resolveMessageProperies(message);
   if (message) {
-    if (message.properties.gist.persistent) {
+    if (messageProperties.persistent) {
       log(`Persistent message dismissed, logging view`);
       reportMessageView(message);
     }
@@ -180,6 +181,7 @@ function handleGistEvents(e) {
   if (e.data.gist) {
     var currentInstanceId = e.data.gist.instanceId;
     var currentMessage = fetchMessageByInstanceId(currentInstanceId);
+    var messageProperties = resolveMessageProperies(currentMessage);
     switch (e.data.gist.method) {
       case "routeLoaded": {
         var timeElapsed = (new Date().getTime() - currentMessage.renderStartTime) * 0.001;
@@ -192,7 +194,7 @@ function handleGistEvents(e) {
             showEmbedComponent(currentMessage.elementId);
           }
 
-          if (currentMessage.properties.gist.persistent) {
+          if (messageProperties.persistent) {
             log(`Persistent message shown, skipping logging view`);
           } else {
             reportMessageView(currentMessage);
@@ -208,7 +210,7 @@ function handleGistEvents(e) {
         var name = e.data.gist.parameters.name;
         Gist.messageAction(currentMessage, action, name);
         
-        if (e.data.gist.parameters.system && !currentMessage.properties.gist.persistent) {
+        if (e.data.gist.parameters.system && !messageProperties.persistent) {
           hideMessage(currentInstanceId);
           break;
         }


### PR DESCRIPTION
Fixes a number of issues when the gist object is not present. Instead of using the message object directly, we're using the resolveMessageProperies function to get the appropriate defaults.