### PR TITLE
Fixes an issue where if a 304 was returned, the queue was being cleared.

### DIFF
--- a/src/managers/queue-manager.js
+++ b/src/managers/queue-manager.js
@@ -75,17 +75,21 @@ export async function pollMessageQueue() {
   if (getUserToken()) {
     if (Gist.isDocumentVisible) {
       var response = await getUserQueue();
-      if (response && (response.status === 200 || response.status === 204 || response.status === 304)) {
+      if (response && (response.status === 200 || response.status === 204)) {
         log(`Message queue checked for user ${getUserToken()}, ${response.data.length} messages found.`);
         if (response.data.length > 0) {
           messages = response.data;
           checkMessageQueue();
         } else {
           messages = [];
-          log(`No messages for user token.`);    
+          log(`No messages for user token.`);
         }
       } else {
-        log(`There was an error while checking message queue.`);
+        if (response.status === 304) {
+          log(`No changes to the queue.`);
+        } else {
+          log(`There was an error while checking message queue.`);
+        }
       }
     } else {
       log(`Document not visible, skipping queue check.`);  


### PR DESCRIPTION
Since the 304 response has an empty body, the local queue was being cleared.