### PR TITLE
Caching 304 responses in local store

### DIFF
--- a/src/managers/queue-manager.js
+++ b/src/managers/queue-manager.js
@@ -77,17 +77,19 @@ export async function pollMessageQueue() {
   if (getUserToken()) {
     if (Gist.isDocumentVisible) {
       var response = await getUserQueue();
+      var responseData = [];
       if (response) {
         if (response.status === 200 || response.status === 204) {
           var expiryDate = new Date(new Date().getTime() + 1 * 60000);
-          setKeyWithExpiryToLocalStore(userQueueLocalStoreName, response, expiryDate);
+          setKeyWithExpiryToLocalStore(userQueueLocalStoreName, response.data, expiryDate);
+          responseData = response.data;
         }
         else if (response.status === 304) {
-          response = getKeyFromLocalStore(userQueueLocalStoreName);
+          responseData = getKeyFromLocalStore(userQueueLocalStoreName);
         }
-        if (response && response.data.length > 0) {
-          log(`Message queue checked for user ${getUserToken()}, ${response.data.length} messages found.`);
-          messages = response.data;
+        if (responseData && responseData.length > 0) {
+          log(`Message queue checked for user ${getUserToken()}, ${responseData.length} messages found.`);
+          messages = responseData;
           checkMessageQueue();
         } else {
           messages = [];


### PR DESCRIPTION
This should fix an issue with persistent messages disappearing after refreshing the browser, issue is detailed here: https://customerio.slack.com/archives/C036FTE6UJ0/p1694744921889529

For now, we're just caching the response output and storing it in the browser's local store, very similar to how iOS does it natively.

Eventually, when other features we're working on are introduced, the local queue will switch to the browser's local store.