### PR TITLE
Duplicate views and multiple messages fixes.

### DIFF
--- a/src/gist.js
+++ b/src/gist.js
@@ -2,7 +2,7 @@ import EventEmitter from "./utilities/event-emitter";
 import { log } from "./utilities/log";
 import { startQueueListener, checkMessageQueue } from "./managers/queue-manager";
 import { setUserToken, clearUserToken, useGuestSession } from "./managers/user-manager";
-import { showMessage, embedMessage, hideMessage, removePersistentMessage } from "./managers/message-manager";
+import { showMessage, embedMessage, hideMessage, removePersistentMessage, fetchMessageByInstanceId } from "./managers/message-manager";
 
 export default class {
   static async setup(config) {
@@ -27,12 +27,12 @@ export default class {
     }
     await startQueueListener();
 
-    document.addEventListener("visibilitychange", () => {
+    document.addEventListener("visibilitychange", async () => {
       if (document.visibilityState === "hidden") {
         this.isDocumentVisible = false;
       } else  {
         this.isDocumentVisible = true;
-        checkMessageQueue();
+        await checkMessageQueue();
       }
     }, false);
   }
@@ -40,7 +40,7 @@ export default class {
   static async setCurrentRoute(route) {
     this.currentRoute = route;
     log(`Current route set to: ${route}`);
-    checkMessageQueue();
+    await checkMessageQueue();
   }
 
   static async setUserToken(userToken, expiryDate) {
@@ -56,10 +56,11 @@ export default class {
     await startQueueListener();
   }
 
-  static dismissMessage(instanceId) {
-    removePersistentMessage(instanceId);
-    hideMessage(instanceId);
-    checkMessageQueue();
+  static async dismissMessage(instanceId) {
+    var message = fetchMessageByInstanceId(instanceId);
+    await hideMessage(message);
+    await removePersistentMessage(message);
+    await checkMessageQueue();
   }
 
   static async embedMessage(message, elementId) {

--- a/src/managers/message-component-manager.js
+++ b/src/managers/message-component-manager.js
@@ -98,14 +98,13 @@ export function showOverlayComponent(message) {
   }
 }
 
-export function hideOverlayComponent() {
+export async function hideOverlayComponent() {
   var message = document.querySelector("#gist-message");
   if (message) {
     message.classList.remove("visible");
-    setTimeout(removeOverlayComponent, 300);
-  } else {
-    removeOverlayComponent();
+    await delay(300);
   }
+  removeOverlayComponent();
 }
 
 export function removeOverlayComponent() {


### PR DESCRIPTION
This PR addresses 2 issues:
1. On some rare occasions, shown messages were being shown twice. [Slack Thread](https://customerio.slack.com/archives/C01QYDKD0SU/p1697828787602979?thread_ts=1696992122.437309&cid=C01QYDKD0SU)
2. When users had multiple messages queued up, there was a possibility for the queue to get stuck in a state where modal messages wouldn't be shown (unless page is refreshed).