### PR TITLE
Fix module name declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,1 @@
-declare module 'Gist';
+declare module 'customerio-gist-web';


### PR DESCRIPTION
Allows `customerio-gist-web` to be imported properly in TS projects.