### PR TITLE
Forces a visible message to intercept pointer events

### DIFF
--- a/src/templates/message.js
+++ b/src/templates/message.js
@@ -34,6 +34,7 @@ export function messageHTMLTemplate(messageProperties, url) {
             }
             #gist-message.visible {
                 opacity: 1;
+                pointer-events: auto;
             }
             #gist-message.center {
                 transform: translate(-50%, -50%);


### PR DESCRIPTION
Addresses issue: https://linear.app/customerio/issue/INAPP-12340/when-another-modal-exists-on-screen-pointer-events-pass-through-in-app