### PR TITLE
Setting iframe title attribute to message title

### DIFF
--- a/src/managers/message-component-manager.js
+++ b/src/managers/message-component-manager.js
@@ -82,7 +82,7 @@ export function resizeComponent(elementId, size, shouldScale) {
 }
 
 export function loadOverlayComponent(url, message) {
-  document.body.insertAdjacentHTML('beforeend', component(url, message));
+  document.body.insertAdjacentHTML('afterbegin', component(url, message));
 }
 
 export function showOverlayComponent(message) {
@@ -114,6 +114,13 @@ export function removeOverlayComponent() {
   var mainMessageElement = document.querySelector("#gist-embed-message");
   if (mainMessageElement) {
     mainMessageElement.parentNode.removeChild(mainMessageElement);
+  }
+}
+
+export function changeOverlayTitle(title) {
+  var element = safelyFetchElement("gist-message");
+  if (element) {
+    element.title = title;
   }
 }
 

--- a/src/managers/message-manager.js
+++ b/src/managers/message-manager.js
@@ -13,7 +13,8 @@ import {
   hideEmbedComponent,
   resizeComponent,
   elementHasHeight,
-  isElementLoaded
+  isElementLoaded,
+  changeOverlayTitle
 } from "./message-component-manager";
 import { resolveMessageProperties } from "./gist-properties-manager";
 import { positions, addPageElement } from "./page-component-manager";
@@ -264,12 +265,17 @@ async function handleGistEvents(e) {
         break;
       }
       case "sizeChanged": {
-        log(`Size Changed Width: ${e.data.gist.parameters.width} - Height: ${e.data.gist.parameters.height}`)
+        log(`Size Changed Width: ${e.data.gist.parameters.width} - Height: ${e.data.gist.parameters.height}`);
         if (currentMessage.elementId && currentMessage.shouldResizeHeight) {
           resizeComponent(currentMessage.elementId, e.data.gist.parameters, currentMessage.shouldScale);
         } else {
           resizeComponent("gist-message", e.data.gist.parameters, currentMessage.shouldScale);
         }
+        break;
+      }
+      case "titleChanged": {
+        log(`Overlay title changed to: ${e.data.gist.parameters.title}`);
+        changeOverlayTitle(e.data.gist.parameters.title);
         break;
       }
       case "error":


### PR DESCRIPTION
In this PR we address the following:
- Change `iframe` title attribute to what's specified within the message
- Change overlay injection to top instead of bottom

Issue: https://linear.app/customerio/issue/INAPP-12366/render-iframe-title-attribute-should-be-set-to-message-title-value