### PR TITLE
Fixes the issue where in some cases if an overlay goes over the max width, all overlays switch to 100%.

### DIFF
--- a/src/managers/message-component-manager.js
+++ b/src/managers/message-component-manager.js
@@ -31,6 +31,7 @@ export async function preloadRenderer() {
 export function loadEmbedComponent(elementId, url, message) {
   var element = safelyFetchElement(elementId);
   if (element) {
+    element.classList.add(getMessageElementId(message.instanceId));
     var messageProperties = resolveMessageProperties(message);
     var messageWidth = messageProperties.messageWidth + "px";
     if (wideOverlayPositions.includes(messageProperties.elementId) && !messageProperties.hasCustomWidth) {

--- a/src/templates/embed.js
+++ b/src/templates/embed.js
@@ -1,4 +1,4 @@
-export function embedHTMLTemplate(instanceId, messageProperties, url) {
+export function embedHTMLTemplate(elementId, messageProperties, url) {
     var maxWidthBreakpoint = 800;
     if (messageProperties.messageWidth > maxWidthBreakpoint) {
         maxWidthBreakpoint = messageProperties.messageWidth;
@@ -39,13 +39,20 @@ export function embedHTMLTemplate(instanceId, messageProperties, url) {
                 border: none;
             }
             @media (max-width: ${maxWidthBreakpoint}px) {
-                #x-gist-top, #x-gist-bottom, #x-gist-floating-top, #x-gist-floating-bottom, #x-gist-floating-top-left, #x-gist-floating-top-right, #x-gist-floating-bottom-left, #x-gist-floating-bottom-right {
-                width: 100% !important;
+                #x-gist-top.${elementId},
+                #x-gist-bottom.${elementId},
+                #x-gist-floating-top.${elementId},
+                #x-gist-floating-bottom.${elementId},
+                #x-gist-floating-top-left.${elementId},
+                #x-gist-floating-top-right.${elementId},
+                #x-gist-floating-bottom-left.${elementId},
+                #x-gist-floating-bottom-right.${elementId} {
+                    width: 100% !important;
                 }
             }
         </style>
         <div id="gist-embed-container">
-            <iframe id="${instanceId}" class="gist-frame" src="${url}"></iframe>
+            <iframe id="${elementId}" class="gist-frame" src="${url}"></iframe>
         </div>
     </div>`;
     return template

--- a/src/templates/message.js
+++ b/src/templates/message.js
@@ -1,4 +1,4 @@
-export function messageHTMLTemplate(instanceId, messageProperties, url) {
+export function messageHTMLTemplate(elementId, messageProperties, url) {
     var maxWidthBreakpoint = 600;
     if (messageProperties.messageWidth > maxWidthBreakpoint) {
       maxWidthBreakpoint = messageProperties.messageWidth;    
@@ -53,7 +53,7 @@ export function messageHTMLTemplate(instanceId, messageProperties, url) {
             }
         </style>
         <div id="gist-overlay" class="background">
-            <iframe id="${instanceId}" class="gist-message" src="${url}"></iframe>
+            <iframe id="${elementId}" class="gist-message" src="${url}"></iframe>
         </div>
     </div>`;
     return template;


### PR DESCRIPTION
Issue: https://linear.app/customerio/issue/INAPP-12467/overlay-width-settings-triggering-100percent-width-in-gist-web-sdk