### PR TITLE
Removed unused variable that caused a crash on the VIte runtime environment.

### DIFF
--- a/src/gist.js
+++ b/src/gist.js
@@ -4,7 +4,7 @@ import { startQueueListener, checkMessageQueue } from "./managers/queue-manager"
 import { setUserToken, clearUserToken, useGuestSession } from "./managers/user-manager";
 import { showMessage, embedMessage, hideMessage, removePersistentMessage, fetchMessageByInstanceId } from "./managers/message-manager";
 import { setUserLocale } from "./managers/locale-manager";
-import { setupPreview, fetchPreviewId } from "./utilities/preview-mode";
+import { setupPreview } from "./utilities/preview-mode";
 
 export default class {
   static async setup(config) {

--- a/src/services/queue-service.js
+++ b/src/services/queue-service.js
@@ -1,4 +1,4 @@
-import { UserNetworkInstance, DefaultHeaders } from './network';
+import { UserNetworkInstance } from './network';
 import { setKeyToLocalStore } from '../utilities/local-storage';
 import { log } from "../utilities/log";
 import { isUsingGuestUserToken } from '../managers/user-manager';


### PR DESCRIPTION
- Removed unused import, `DefaultHeaders`in `src/services/queue-service.js`, it was never defined in `src/services/network.js`
- Removed unused import, `fetchPreviewId` in `src/gist.js`, it was defined but not exported from `src/utilities/preview-mode.js`.