### PR TITLE
Support larger rendering input

### DIFF
--- a/src/managers/message-manager.js
+++ b/src/managers/message-manager.js
@@ -126,28 +126,20 @@ function loadMessageComponent(message, elementId = null) {
     livePreview: false,
     properties: message.properties
   }
-  var url = `${settings.GIST_VIEW_ENDPOINT[Gist.config.env]}/index.html?options=${encodeUnicode(JSON.stringify(options))}`
+  var url = `${settings.GIST_VIEW_ENDPOINT[Gist.config.env]}/index.html`
   window.addEventListener('message', handleGistEvents);
   window.addEventListener('touchstart', handleTouchStartEvents);
 
   if (elementId) {
     if (positions.includes(elementId)) { addPageElement(elementId); }
-    loadEmbedComponent(elementId, url, message);
+    loadEmbedComponent(elementId, url, message, options);
   } else {
-    loadOverlayComponent(url, message);
+    loadOverlayComponent(url, message, options);
   }
 
   return message;
 }
 
-function encodeUnicode(str) {
-  var base64Unicode = btoa(encodeURIComponent(str).replace(/%([0-9A-F]{2})/g,
-      function toSolidBytes(match, p1) {
-          return String.fromCharCode('0x' + p1);
-  }));
-
-  return encodeURIComponent(base64Unicode);
-}
 
 async function reportMessageView(message) {
   log(`Message shown, logging view for: ${message.messageId}`);

--- a/src/services/settings.js
+++ b/src/services/settings.js
@@ -11,7 +11,7 @@ export const settings = {
   },
   GIST_VIEW_ENDPOINT: {
     "prod": "https://renderer.gist.build/2.0",
-    "dev": "https://renderer.gist.build/2.0",
+    "dev": "https://renderer.gist.build/beta",
     "local": "http://app.local.gist.build:8080/web"
   }
 }


### PR DESCRIPTION
Linear issue: https://linear.app/customerio/issue/INAPP-12777/request-header-too-large-preventing-in-app-messages-from-rendering

The plan is to pass the data to the iframe using postMessage instead of using a query parameter. If I can figure out how to do this for android I think we may be ok