### PR TITLE
fix: change entryfile for esm imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "browser": "dist/gist.min.js",
   "exports": {
     "require": "./dist/gist.min.js",
-    "import": "./src/index.js"
+    "import": "./src/gist.js"
   },
   "author": "Customer.io (https://customer.io)",
   "license": "SEE LICENSE IN LICENSE",


### PR DESCRIPTION
We're using this package to bring customer.io In-App Messages into our app without using the CDP packages.

Vite is our bundler and throws this error when trying to load our app.
```
Uncaught SyntaxError: The requested module '/_nuxt/node_modules/customerio-gist-web/src/index.js?v=af707f79' does not provide an export named 'default' (at index.ts?v=af707f79:1:8)
```

We were able to workaround this by changing the entrypoint of the package like this in our vite config:
```
    resolve: {
      alias: {
        'customerio-gist-web': '/node_modules/customerio-gist-web/src/gist.js',
      },
    },
```

This PR aims to change the default entrypoint for ESM imports to that path directly.