### PR TITLE
[in-app-broadcast] hide anonymous message if user dismisses it

### DIFF
--- a/src/managers/message-broadcast-manager.js
+++ b/src/managers/message-broadcast-manager.js
@@ -54,6 +54,19 @@ export async function markBroadcastAsSeen(broadcastId) {
   }
 }
 
+export async function markBroadcastAsDismissed(broadcastId) {
+  log(`Marking broadcast ${broadcastId} as dismissed.`);
+  const messageBroadcastLocalStoreName = await getMessageBroadcastLocalStoreName();
+  if (!messageBroadcastLocalStoreName) return;
+  
+  const broadcast = await fetchMessageBroadcast(messageBroadcastLocalStoreName, broadcastId);
+  if (!broadcast) return;
+
+  const broadcastShouldShowLocalStoreName = getBroadcastShouldShowLocalStoreName(messageBroadcastLocalStoreName, broadcastId);
+  setKeyToLocalStore(broadcastShouldShowLocalStoreName, false);
+  log(`Marked broadcast ${broadcastId} as dismissed and will not show again.`);
+}
+
 async function fetchMessageBroadcast(messageBroadcastLocalStoreName, broadcastId) {
   const broadcasts = getKeyFromLocalStore(messageBroadcastLocalStoreName);
   return broadcasts.find(message => message.queueId === broadcastId);

--- a/src/managers/message-manager.js
+++ b/src/managers/message-manager.js
@@ -230,6 +230,7 @@ async function handleGistEvents(e) {
               case "close":
                 await hideMessage(currentMessage);
                 await removePersistentMessage(currentMessage);
+                await logBroadcastDismissedLocally(currentMessage);
                 await checkMessageQueue();
                 break;
               case "showMessage":
@@ -301,5 +302,12 @@ async function logUserMessageViewLocally(message) {
     await markBroadcastAsSeen(message.queueId);
   } else {
     await markUserQueueMessageAsSeen(message.queueId);
+  }
+}
+
+async function logBroadcastDismissedLocally(message) {
+  if (isMessageBroadcast(message)) {
+    log(`Logging broadcast dismissed locally for: ${message.queueId}`);
+    await markBroadcastAsDismissed(message.queueId);
   }
 }


### PR DESCRIPTION
Part of INAPP-12844

Updating a default behavior, i.e if a user dismisses an anonymous message, lets not pester them with showing it again. 

We're planning to make it configurable in a future release.