### PR TITLE
Update to the latest renderer

### DIFF
--- a/src/services/settings.js
+++ b/src/services/settings.js
@@ -10,8 +10,8 @@ export const settings = {
     "local": "http://api.local.gist.build:86"
   },
   GIST_VIEW_ENDPOINT: {
-    "prod": "https://renderer.gist.build/2.0",
-    "dev": "https://renderer.gist.build/beta",
+    "prod": "https://renderer.gist.build/3.0",
+    "dev": "https://renderer.gist.build/3.0",
     "local": "http://app.local.gist.build:8080/web"
   }
 }


### PR DESCRIPTION
Linear issue: https://linear.app/customerio/issue/INAPP-12777/request-header-too-large-preventing-in-app-messages-from-rendering

This is technically the same version as the beta, but we need to use the proper url for the release.