### PR TITLE
Add support for mailto on same page links

### DIFF
--- a/src/managers/message-manager.js
+++ b/src/managers/message-manager.js
@@ -242,7 +242,7 @@ async function handleGistEvents(e) {
               case "loadPage":
                 url = url.href.substring(url.href.indexOf('?url=') + 5);
                 if (url) {
-                  if (url.startsWith("https://") || url.startsWith("http://") || url.startsWith("/")) {
+                  if (url.startsWith("mailto:") || url.startsWith("https://") || url.startsWith("http://") || url.startsWith("/")) {
                     window.location.href = url;
                   } else {
                     window.location.href = window.location + url;


### PR DESCRIPTION
Part of: [INAPP-13076](https://linear.app/customerio/issue/INAPP-13076/in-app-support-mailto-links-with-apostrophe-characters)