### PR TITLE
Prefixed CSS Styles

### DIFF
--- a/src/managers/message-component-manager.js
+++ b/src/managers/message-component-manager.js
@@ -110,12 +110,12 @@ export function showOverlayComponent(message) {
   var messageProperties = resolveMessageProperties(message);
   var mainMessageElement = document.querySelector("#gist-overlay");
   if (mainMessageElement) {
-    mainMessageElement.classList.add("visible");
+    mainMessageElement.classList.add("gist-visible");
     var messageElement = document.querySelector(".gist-message");
     if (message.position) {
-      messageElement.classList.add(message.position);
+      messageElement.classList.add("gist-" + message.position);
     } else {
-      messageElement.classList.add("center");
+      messageElement.classList.add("gist-center");
     }
     setTimeout(showMessage, 100);
     // If exitClick is set to true, we add a dismiss listener after a 1-second delay to prevent accidental dismissals.
@@ -138,7 +138,7 @@ function addDismissListener(instanceId) {
 export async function hideOverlayComponent() {
   var message = document.querySelector(".gist-message");
   if (message) {
-    message.classList.remove("visible");
+    message.classList.remove("gist-visible");
     await delay(300);
   }
   removeOverlayComponent();
@@ -164,7 +164,7 @@ function getMessageElementId(instanceId) {
 
 function showMessage() {
   var messageElement = document.querySelector(".gist-message");
-  if (messageElement) messageElement.classList.add("visible");
+  if (messageElement) messageElement.classList.add("gist-visible");
 }
 
 function embed(url, message, messageProperties) {

--- a/src/managers/queue-manager.js
+++ b/src/managers/queue-manager.js
@@ -49,7 +49,7 @@ async function handleMessage(message) {
       currentUrl = new URL(window.location.href).pathname;
     }
     var routeRule = messageProperties.routeRule;
-    log(`Verifying route against rule: ${routeRule}`);
+    log(`Verifying route ${currentUrl} against rule: ${routeRule}`);
     var urlTester = new RegExp(routeRule);
     if (!urlTester.test(currentUrl)) {
       log(`Route ${currentUrl} does not match rule.`);

--- a/src/templates/message.js
+++ b/src/templates/message.js
@@ -6,7 +6,7 @@ export function messageHTMLTemplate(elementId, messageProperties, url) {
     var template = `
     <div id="gist-embed-message">
         <style>
-            #gist-overlay.background {
+            #gist-overlay.gist-background {
                 position: fixed;
                 z-index: 9999999998;
                 left: 0;
@@ -16,11 +16,8 @@ export function messageHTMLTemplate(elementId, messageProperties, url) {
                 background-color: ${messageProperties.overlayColor};
                 visibility: hidden;
             }
-            #gist-overlay.background.visible {
+            #gist-overlay.gist-background.gist-visible {
                 visibility: visible;
-            }
-            #gist-overlay.background.is-blacked-out {
-                display: block;
             }
             .gist-message {
                 width: ${messageProperties.messageWidth}px;
@@ -32,18 +29,18 @@ export function messageHTMLTemplate(elementId, messageProperties, url) {
                 left: 50%;
                 transform: translateX(-50%);
             }
-            .gist-message.visible {
+            .gist-message.gist-visible {
                 opacity: 1;
                 pointer-events: auto;
             }
-            .gist-message.center {
+            .gist-message.gist-center {
                 transform: translate(-50%, -50%);
                 top: 50%;
             }
-            .gist-message.bottom {
+            .gist-message.gist-bottom {
                 bottom: 0;
             }
-            .gist-message.top {
+            .gist-message.gist-top {
                 top: 0;
             }
             @media (max-width: ${maxWidthBreakpoint}px) {
@@ -52,7 +49,7 @@ export function messageHTMLTemplate(elementId, messageProperties, url) {
                 }
             }
         </style>
-        <div id="gist-overlay" class="background">
+        <div id="gist-overlay" class="gist-background">
             <iframe id="${elementId}" class="gist-message" src="${url}"></iframe>
         </div>
     </div>`;


### PR DESCRIPTION
Prefixed styles with `gist-` to make sure there are no collisions with other site styles.

Addresses: [INAPP-13637](https://linear.app/customerio/issue/INAPP-13637/in-app-messages-are-not-visible-when-site-loads-twindstyle-plugin)