### PR TITLE
Sets local store expiry to 10 minutes for broadcasts and user queue.

### DIFF
--- a/src/managers/message-broadcast-manager.js
+++ b/src/managers/message-broadcast-manager.js
@@ -3,7 +3,7 @@ import { setKeyToLocalStore, getKeyFromLocalStore } from '../utilities/local-sto
 import { getHashedUserToken } from './user-manager';
 
 const broadcastsLocalStoreName = "gist.web.message.broadcasts";
-const broadcastsExpiryInMinutes = 10;
+const broadcastsExpiryInMinutes = 60;
 
 export async function updateBroadcastsLocalStore(messages) {
   const messageBroadcastLocalStoreName = await getMessageBroadcastLocalStoreName();

--- a/src/managers/message-broadcast-manager.js
+++ b/src/managers/message-broadcast-manager.js
@@ -3,14 +3,14 @@ import { setKeyToLocalStore, getKeyFromLocalStore } from '../utilities/local-sto
 import { getHashedUserToken } from './user-manager';
 
 const broadcastsLocalStoreName = "gist.web.message.broadcasts";
-const broadcastsExpiryInDays = 30;
+const broadcastsExpiryInMinutes = 10;
 
 export async function updateBroadcastsLocalStore(messages) {
   const messageBroadcastLocalStoreName = await getMessageBroadcastLocalStoreName();
   if (!messageBroadcastLocalStoreName) return;
 
   const expiryDate = new Date();
-  expiryDate.setDate(expiryDate.getDate() + broadcastsExpiryInDays);
+  expiryDate.setMinutes(expiryDate.getMinutes() + broadcastsExpiryInMinutes);
 
   const messagesWithBroadcast = messages.filter(isMessageBroadcast);
   setKeyToLocalStore(messageBroadcastLocalStoreName, messagesWithBroadcast, expiryDate);

--- a/src/managers/message-user-queue-manager.js
+++ b/src/managers/message-user-queue-manager.js
@@ -2,7 +2,7 @@ import { getKeyFromLocalStore, setKeyToLocalStore, clearKeyFromLocalStore } from
 import { getHashedUserToken } from './user-manager';
 
 const messageQueueLocalStoreName = "gist.web.message.user";
-const messagesLocalStoreCacheInMinutes = 60000 * 60;
+const messagesLocalStoreCacheInMinutes = 10;
 
 
 export async function updateQueueLocalStore(messages) {
@@ -12,7 +12,8 @@ export async function updateQueueLocalStore(messages) {
   const nonBroadcasts = messages.filter(message => 
     !(message.properties && message.properties.gist && message.properties.gist.broadcast)
   );
-  const expiryDate = new Date(Date.now() + messagesLocalStoreCacheInMinutes);
+  const expiryDate = new Date();
+  expiryDate.setMinutes(expiryDate.getMinutes() + messagesLocalStoreCacheInMinutes);
   setKeyToLocalStore(userQueueLocalStoreName, nonBroadcasts, expiryDate);
 }
 

--- a/src/managers/message-user-queue-manager.js
+++ b/src/managers/message-user-queue-manager.js
@@ -2,7 +2,7 @@ import { getKeyFromLocalStore, setKeyToLocalStore, clearKeyFromLocalStore } from
 import { getHashedUserToken } from './user-manager';
 
 const messageQueueLocalStoreName = "gist.web.message.user";
-const messagesLocalStoreCacheInMinutes = 10;
+const messagesLocalStoreCacheInMinutes = 60;
 
 
 export async function updateQueueLocalStore(messages) {

--- a/src/utilities/local-storage.js
+++ b/src/utilities/local-storage.js
@@ -29,7 +29,7 @@ export function getKeyFromLocalStore(key) {
     const expiryTime = new Date(item.expiry);
     
     // Retroactive bugfix: remove old cache entries with long expiry times
-    const isBroadcastOrUserKey = (key.startsWith("gist.web.message.broadcasts") && !key.endsWith("shouldShow")) || key.startsWith("gist.web.message.user");
+    const isBroadcastOrUserKey = (key.startsWith("gist.web.message.broadcasts") && !key.endsWith("shouldShow") && !key.endsWith("numberOfTimesShown")) || key.startsWith("gist.web.message.user");
     const sixtyMinutesFromNow = new Date(now.getTime() + 61 * 60 * 1000);
     if (isBroadcastOrUserKey && expiryTime.getTime() > sixtyMinutesFromNow.getTime()) {
         clearKeyFromLocalStore(key);

--- a/src/utilities/local-storage.js
+++ b/src/utilities/local-storage.js
@@ -29,7 +29,7 @@ export function getKeyFromLocalStore(key) {
     const expiryTime = new Date(item.expiry);
     
     // Retroactive bugfix: remove old cache entries with long expiry times
-    const isBroadcastOrUserKey = key.startsWith("gist.web.message.broadcasts") || key.startsWith("gist.web.message.user");
+    const isBroadcastOrUserKey = (key.startsWith("gist.web.message.broadcasts") && !key.endsWith("shouldShow")) || key.startsWith("gist.web.message.user");
     const sixtyMinutesFromNow = new Date(now.getTime() + 61 * 60 * 1000);
     if (isBroadcastOrUserKey && expiryTime.getTime() > sixtyMinutesFromNow.getTime()) {
         clearKeyFromLocalStore(key);

--- a/src/utilities/local-storage.js
+++ b/src/utilities/local-storage.js
@@ -29,7 +29,7 @@ export function getKeyFromLocalStore(key) {
     const expiryTime = new Date(item.expiry);
     
     // Retroactive bugfix: remove old cache entries with long expiry times
-    const isBroadcastOrUserKey = (key.startsWith("gist.web.message.broadcasts") && !key.endsWith("shouldShow") && !key.endsWith("numberOfTimesShown")) || (key.startsWith("gist.web.message.user" && !key.endsWith("seen")));
+    const isBroadcastOrUserKey = (key.startsWith("gist.web.message.broadcasts") && !key.endsWith("shouldShow") && !key.endsWith("numberOfTimesShown")) || (key.startsWith("gist.web.message.user") && !key.endsWith("seen"));
     const sixtyMinutesFromNow = new Date(now.getTime() + 61 * 60 * 1000);
     if (isBroadcastOrUserKey && expiryTime.getTime() > sixtyMinutesFromNow.getTime()) {
         clearKeyFromLocalStore(key);

--- a/src/utilities/local-storage.js
+++ b/src/utilities/local-storage.js
@@ -26,7 +26,17 @@ export function getKeyFromLocalStore(key) {
 
     const item = JSON.parse(itemStr);
     const now = new Date();
-    if (now.getTime() > new Date(item.expiry).getTime()) {
+    const expiryTime = new Date(item.expiry);
+    
+    // Retroactive bugfix: remove old cache entries with long expiry times
+    const isBroadcastOrUserKey = key.startsWith("gist.web.message.broadcasts") || key.startsWith("gist.web.message.user");
+    const sixtyMinutesFromNow = new Date(now.getTime() + 61 * 60 * 1000);
+    if (isBroadcastOrUserKey && expiryTime.getTime() > sixtyMinutesFromNow.getTime()) {
+        clearKeyFromLocalStore(key);
+        return null;
+    }
+    
+    if (now.getTime() > expiryTime.getTime()) {
         clearKeyFromLocalStore(key);
         return null;
     }

--- a/src/utilities/local-storage.js
+++ b/src/utilities/local-storage.js
@@ -29,7 +29,7 @@ export function getKeyFromLocalStore(key) {
     const expiryTime = new Date(item.expiry);
     
     // Retroactive bugfix: remove old cache entries with long expiry times
-    const isBroadcastOrUserKey = (key.startsWith("gist.web.message.broadcasts") && !key.endsWith("shouldShow") && !key.endsWith("numberOfTimesShown")) || key.startsWith("gist.web.message.user");
+    const isBroadcastOrUserKey = (key.startsWith("gist.web.message.broadcasts") && !key.endsWith("shouldShow") && !key.endsWith("numberOfTimesShown")) || (key.startsWith("gist.web.message.user" && !key.endsWith("seen")));
     const sixtyMinutesFromNow = new Date(now.getTime() + 61 * 60 * 1000);
     if (isBroadcastOrUserKey && expiryTime.getTime() > sixtyMinutesFromNow.getTime()) {
         clearKeyFromLocalStore(key);


### PR DESCRIPTION
Addresses: [INAPP-13728](https://linear.app/customerio/issue/INAPP-13728/expired-anonymous-in-app-messages-continue-to-display-and-track)