### PR TITLE
adding guard for local storage key prefix

### DIFF
--- a/src/utilities/local-storage.test.ts
+++ b/src/utilities/local-storage.test.ts
@@ -27,10 +27,10 @@ describe('local-storage', () => {
     expect(getKeyFromLocalStore('gist.nonexistent')).toBeNull();
   });
 
-  it('getKeyFromLocalStore returns null for keys not starting with "gist."', () => {
+  it('getKeyFromLocalStore returns value for keys not starting with "gist." and does not delete them', () => {
     shouldPersistSession(true);
     setKeyToLocalStore('other.key', 'value');
-    expect(getKeyFromLocalStore('other.key')).toBeNull();
+    expect(getKeyFromLocalStore('other.key')).toBe('value');
     expect(getKeyFromLocalStore('nonexistent')).toBeNull();
   });
 

--- a/src/utilities/local-storage.test.ts
+++ b/src/utilities/local-storage.test.ts
@@ -18,54 +18,61 @@ describe('local-storage', () => {
 
   it('setKeyToLocalStore / getKeyFromLocalStore round-trips a value', () => {
     shouldPersistSession(true);
-    setKeyToLocalStore('test-key', { foo: 'bar' });
-    expect(getKeyFromLocalStore('test-key')).toEqual({ foo: 'bar' });
+    setKeyToLocalStore('gist.test-key', { foo: 'bar' });
+    expect(getKeyFromLocalStore('gist.test-key')).toEqual({ foo: 'bar' });
   });
 
   it('getKeyFromLocalStore returns null for a missing key', () => {
     shouldPersistSession(true);
+    expect(getKeyFromLocalStore('gist.nonexistent')).toBeNull();
+  });
+
+  it('getKeyFromLocalStore returns null for keys not starting with "gist."', () => {
+    shouldPersistSession(true);
+    setKeyToLocalStore('other.key', 'value');
+    expect(getKeyFromLocalStore('other.key')).toBeNull();
     expect(getKeyFromLocalStore('nonexistent')).toBeNull();
   });
 
   it('expired keys return null and are removed from storage', () => {
     shouldPersistSession(true);
     const pastDate = new Date(Date.now() - 1000);
-    setKeyToLocalStore('expired-key', 'value', pastDate);
-    expect(getKeyFromLocalStore('expired-key')).toBeNull();
-    expect(localStorage.getItem('expired-key')).toBeNull();
+    setKeyToLocalStore('gist.expired-key', 'value', pastDate);
+    expect(getKeyFromLocalStore('gist.expired-key')).toBeNull();
+    expect(localStorage.getItem('gist.expired-key')).toBeNull();
   });
 
   it('clearKeyFromLocalStore removes a key', () => {
     shouldPersistSession(true);
-    setKeyToLocalStore('to-clear', 'value');
-    expect(getKeyFromLocalStore('to-clear')).toBe('value');
-    clearKeyFromLocalStore('to-clear');
-    expect(getKeyFromLocalStore('to-clear')).toBeNull();
+    setKeyToLocalStore('gist.to-clear', 'value');
+    expect(getKeyFromLocalStore('gist.to-clear')).toBe('value');
+    clearKeyFromLocalStore('gist.to-clear');
+    expect(getKeyFromLocalStore('gist.to-clear')).toBeNull();
   });
 
   it('clearExpiredFromLocalStore removes all expired keys, keeps non-expired', () => {
     shouldPersistSession(true);
     const pastDate = new Date(Date.now() - 1000);
-    setKeyToLocalStore('expired', 'old', pastDate);
-    setKeyToLocalStore('valid', 'new');
+    setKeyToLocalStore('gist.expired', 'old', pastDate);
+    setKeyToLocalStore('gist.valid', 'new');
     clearExpiredFromLocalStore();
-    expect(getKeyFromLocalStore('expired')).toBeNull();
-    expect(getKeyFromLocalStore('valid')).toBe('new');
+    expect(getKeyFromLocalStore('gist.expired')).toBeNull();
+    expect(getKeyFromLocalStore('gist.valid')).toBe('new');
   });
 
   it('shouldPersistSession(false) causes storage to use sessionStorage', () => {
     shouldPersistSession(false);
-    setKeyToLocalStore('session-key', 'session-value');
-    expect(getKeyFromLocalStore('session-key')).toBe('session-value');
+    setKeyToLocalStore('gist.session-key', 'session-value');
+    expect(getKeyFromLocalStore('gist.session-key')).toBe('session-value');
     expect(sessionStorage.length).toBeGreaterThan(0);
-    expect(localStorage.getItem('session-key')).toBeNull();
+    expect(localStorage.getItem('gist.session-key')).toBeNull();
   });
 
   it('shouldPersistSession(true) causes storage to use localStorage', () => {
     shouldPersistSession(true);
-    setKeyToLocalStore('local-key', 'local-value');
-    expect(getKeyFromLocalStore('local-key')).toBe('local-value');
-    expect(localStorage.getItem('local-key')).not.toBeNull();
+    setKeyToLocalStore('gist.local-key', 'local-value');
+    expect(getKeyFromLocalStore('gist.local-key')).toBe('local-value');
+    expect(localStorage.getItem('gist.local-key')).not.toBeNull();
   });
 
   it('broadcast/user keys with expiry >60 minutes in the future are cleared', () => {

--- a/src/utilities/local-storage.ts
+++ b/src/utilities/local-storage.ts
@@ -62,7 +62,7 @@ function getStorage(): Storage {
 }
 
 function checkKeyForExpiry(key: string | null): unknown | null {
-  if (!key) return null;
+  if (!key || !key.startsWith('gist.')) return null;
 
   try {
     const itemStr = getStorage().getItem(key);

--- a/src/utilities/local-storage.ts
+++ b/src/utilities/local-storage.ts
@@ -62,7 +62,7 @@ function getStorage(): Storage {
 }
 
 function checkKeyForExpiry(key: string | null): unknown | null {
-  if (!key || !key.startsWith('gist.')) return null;
+  if (key?.startsWith('gist.') !== true) return null;
 
   try {
     const itemStr = getStorage().getItem(key);

--- a/src/utilities/local-storage.ts
+++ b/src/utilities/local-storage.ts
@@ -36,7 +36,9 @@ export function clearKeyFromLocalStore(key: string): void {
 export function clearExpiredFromLocalStore(): void {
   const storage = getStorage();
   for (let i = storage.length - 1; i >= 0; i--) {
-    checkKeyForExpiry(storage.key(i));
+    if (storage.key(i)?.startsWith('gist.')) {
+      checkKeyForExpiry(storage.key(i));
+    }
   }
 }
 
@@ -62,7 +64,7 @@ function getStorage(): Storage {
 }
 
 function checkKeyForExpiry(key: string | null): unknown | null {
-  if (key?.startsWith('gist.') !== true) return null;
+  if (!key) return null;
 
   try {
     const itemStr = getStorage().getItem(key);
@@ -71,23 +73,27 @@ function checkKeyForExpiry(key: string | null): unknown | null {
     const item = JSON.parse(itemStr) as StoredItem;
     if (!item.expiry) return item.value;
 
-    const now = new Date();
-    const expiryTime = new Date(item.expiry);
+    if (key.startsWith('gist.')) {
+      const now = new Date();
+      const expiryTime = new Date(item.expiry);
 
-    const isBroadcastOrUserKey =
-      (key.startsWith('gist.web.message.broadcasts') &&
-        !key.endsWith('shouldShow') &&
-        !key.endsWith('numberOfTimesShown')) ||
-      (key.startsWith('gist.web.message.user') && !key.endsWith('seen') && !key.endsWith('state'));
-    const sixtyMinutesFromNow = new Date(now.getTime() + 61 * 60 * 1000);
-    if (isBroadcastOrUserKey && expiryTime.getTime() > sixtyMinutesFromNow.getTime()) {
-      clearKeyFromLocalStore(key);
-      return null;
-    }
+      const isBroadcastOrUserKey =
+        (key.startsWith('gist.web.message.broadcasts') &&
+          !key.endsWith('shouldShow') &&
+          !key.endsWith('numberOfTimesShown')) ||
+        (key.startsWith('gist.web.message.user') &&
+          !key.endsWith('seen') &&
+          !key.endsWith('state'));
+      const sixtyMinutesFromNow = new Date(now.getTime() + 61 * 60 * 1000);
+      if (isBroadcastOrUserKey && expiryTime.getTime() > sixtyMinutesFromNow.getTime()) {
+        clearKeyFromLocalStore(key);
+        return null;
+      }
 
-    if (now.getTime() > expiryTime.getTime()) {
-      clearKeyFromLocalStore(key);
-      return null;
+      if (now.getTime() > expiryTime.getTime()) {
+        clearKeyFromLocalStore(key);
+        return null;
+      }
     }
 
     return item.value;

--- a/src/utilities/local-storage.ts
+++ b/src/utilities/local-storage.ts
@@ -36,8 +36,9 @@ export function clearKeyFromLocalStore(key: string): void {
 export function clearExpiredFromLocalStore(): void {
   const storage = getStorage();
   for (let i = storage.length - 1; i >= 0; i--) {
-    if (storage.key(i)?.startsWith('gist.')) {
-      checkKeyForExpiry(storage.key(i));
+    const key = storage.key(i);
+    if (key?.startsWith('gist.')) {
+      checkKeyForExpiry(key);
     }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes local/session storage cleanup behavior so expiry logic no longer runs for non-`gist.` keys, which could leave stale entries if any callers rely on expiry for other prefixes. Scope is small but affects persistence/cleanup semantics.
> 
> **Overview**
> Adds a `gist.` prefix guard to local/session storage expiry handling so only `gist.`-namespaced keys are checked and auto-removed during `clearExpiredFromLocalStore()` and `getKeyFromLocalStore()`.
> 
> Updates tests to consistently use `gist.*` keys and adds coverage ensuring non-`gist.` keys can still be read without being deleted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f257b03af681f96806ef4fa14bf2ac42d6c8f7da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->