### PR TITLE
consolidating storage keys

### DIFF
--- a/src/managers/custom-attribute-manager.test.ts
+++ b/src/managers/custom-attribute-manager.test.ts
@@ -13,6 +13,9 @@ vi.mock('../utilities/local-storage', () => ({
   setKeyToLocalStore: vi.fn(),
   getKeyFromLocalStore: vi.fn(() => null),
   clearKeyFromLocalStore: vi.fn(),
+  STORAGE_KEYS: {
+    customAttributes: 'gist.web.customAttributes',
+  },
 }));
 
 describe('custom-attribute-manager', () => {

--- a/src/managers/custom-attribute-manager.ts
+++ b/src/managers/custom-attribute-manager.ts
@@ -3,15 +3,14 @@ import {
   setKeyToLocalStore,
   getKeyFromLocalStore,
   clearKeyFromLocalStore,
+  STORAGE_KEYS,
 } from '../utilities/local-storage';
-
-const customAttributesLocalStoreName = 'gist.web.customAttributes';
 const defaultExpiryInDays = 30;
 
 let customAttributesMap: Map<string, unknown> = new Map();
 
 function loadCustomAttributesFromStorage(): void {
-  const storedAttributes = getKeyFromLocalStore(customAttributesLocalStoreName);
+  const storedAttributes = getKeyFromLocalStore(STORAGE_KEYS.customAttributes);
   if (storedAttributes) {
     try {
       customAttributesMap = new Map(storedAttributes as Iterable<[string, unknown]>);
@@ -27,7 +26,7 @@ function saveCustomAttributesToStorage(): void {
   const attributesArray = Array.from(customAttributesMap.entries());
   const expiryDate = new Date();
   expiryDate.setDate(expiryDate.getDate() + defaultExpiryInDays);
-  setKeyToLocalStore(customAttributesLocalStoreName, attributesArray, expiryDate);
+  setKeyToLocalStore(STORAGE_KEYS.customAttributes, attributesArray, expiryDate);
   log(
     `Saved ${customAttributesMap.size} custom attributes to storage with TTL of ${defaultExpiryInDays} days`
   );
@@ -60,7 +59,7 @@ export function getAllCustomAttributes(): Map<string, unknown> {
 
 export function clearCustomAttributes(): void {
   customAttributesMap.clear();
-  clearKeyFromLocalStore(customAttributesLocalStoreName);
+  clearKeyFromLocalStore(STORAGE_KEYS.customAttributes);
   log(`Cleared all custom attributes`);
 }
 
@@ -74,7 +73,7 @@ export function removeCustomAttribute(key: string): boolean {
   if (customAttributesMap.size > 0) {
     saveCustomAttributesToStorage();
   } else {
-    clearKeyFromLocalStore(customAttributesLocalStoreName);
+    clearKeyFromLocalStore(STORAGE_KEYS.customAttributes);
   }
   log(`Removed custom attribute "${key}"`);
   return existed;

--- a/src/managers/inbox-message-manager.test.ts
+++ b/src/managers/inbox-message-manager.test.ts
@@ -17,6 +17,9 @@ vi.mock('../utilities/log', () => ({ log: vi.fn() }));
 vi.mock('../utilities/local-storage', () => ({
   setKeyToLocalStore: vi.fn(),
   getKeyFromLocalStore: vi.fn(() => null),
+  STORAGE_KEYS: {
+    inboxMessages: 'gist.web.inbox.messages',
+  },
 }));
 vi.mock('./user-manager', () => ({
   getHashedUserToken: vi.fn(() => Promise.resolve('hashed-token')),

--- a/src/managers/inbox-message-manager.ts
+++ b/src/managers/inbox-message-manager.ts
@@ -1,5 +1,5 @@
 import Gist from '../gist';
-import { getKeyFromLocalStore, setKeyToLocalStore } from '../utilities/local-storage';
+import { getKeyFromLocalStore, setKeyToLocalStore, STORAGE_KEYS } from '../utilities/local-storage';
 import { getHashedUserToken } from './user-manager';
 import { log } from '../utilities/log';
 import { logUserMessageView } from '../services/log-service';
@@ -18,7 +18,6 @@ export interface InboxMessage {
 
 const messageInboxUpdatedEventName = 'messageInboxUpdated';
 const inboxMessageEventName = 'inboxMessageAction';
-const inboxMessagesLocalStoreName = 'gist.web.inbox.messages';
 const inboxMessagesLocalStoreCacheInMinutes = 60;
 
 export async function updateInboxMessagesLocalStore(messages: InboxMessage[]): Promise<void> {
@@ -122,5 +121,5 @@ export async function removeInboxMessage(queueId: string): Promise<void> {
 async function getInboxMessagesLocalStoreName(): Promise<string | null> {
   const userToken = await getHashedUserToken();
   if (!userToken) return null;
-  return `${inboxMessagesLocalStoreName}.${userToken}`;
+  return `${STORAGE_KEYS.inboxMessages}.${userToken}`;
 }

--- a/src/managers/locale-manager.test.ts
+++ b/src/managers/locale-manager.test.ts
@@ -6,6 +6,9 @@ vi.mock('../utilities/log', () => ({ log: vi.fn() }));
 vi.mock('../utilities/local-storage', () => ({
   setKeyToLocalStore: vi.fn(),
   getKeyFromLocalStore: vi.fn(() => null),
+  STORAGE_KEYS: {
+    userLocale: 'gist.web.userLocale',
+  },
 }));
 
 describe('locale-manager', () => {

--- a/src/managers/locale-manager.ts
+++ b/src/managers/locale-manager.ts
@@ -1,9 +1,8 @@
 import { log } from '../utilities/log';
-import { setKeyToLocalStore, getKeyFromLocalStore } from '../utilities/local-storage';
-const userLocaleLocalStoreName = 'gist.web.userLocale';
+import { setKeyToLocalStore, getKeyFromLocalStore, STORAGE_KEYS } from '../utilities/local-storage';
 
 export function getUserLocale(): string {
-  const stored = getKeyFromLocalStore(userLocaleLocalStoreName);
+  const stored = getKeyFromLocalStore(STORAGE_KEYS.userLocale);
   if (stored !== null) {
     return stored as string;
   }
@@ -11,6 +10,6 @@ export function getUserLocale(): string {
 }
 
 export function setUserLocale(locale: string): void {
-  setKeyToLocalStore(userLocaleLocalStoreName, locale);
+  setKeyToLocalStore(STORAGE_KEYS.userLocale, locale);
   log(`Set user locate to "${locale}"`);
 }

--- a/src/managers/message-broadcast-manager.test.ts
+++ b/src/managers/message-broadcast-manager.test.ts
@@ -12,6 +12,9 @@ vi.mock('../utilities/log', () => ({ log: vi.fn() }));
 vi.mock('../utilities/local-storage', () => ({
   setKeyToLocalStore: vi.fn(),
   getKeyFromLocalStore: vi.fn(() => null),
+  STORAGE_KEYS: {
+    messageBroadcasts: 'gist.web.message.broadcasts',
+  },
 }));
 vi.mock('./user-manager', () => ({
   getHashedUserToken: vi.fn(() => Promise.resolve('hashed-token')),

--- a/src/managers/message-broadcast-manager.ts
+++ b/src/managers/message-broadcast-manager.ts
@@ -1,9 +1,8 @@
 import { log } from '../utilities/log';
-import { setKeyToLocalStore, getKeyFromLocalStore } from '../utilities/local-storage';
+import { setKeyToLocalStore, getKeyFromLocalStore, STORAGE_KEYS } from '../utilities/local-storage';
 import { getHashedUserToken } from './user-manager';
 import type { GistMessage } from '../types';
 
-const broadcastsLocalStoreName = 'gist.web.message.broadcasts';
 const broadcastsExpiryInMinutes = 60;
 
 interface BroadcastFrequency {
@@ -137,7 +136,7 @@ export function isShowAlwaysBroadcast(message: GistMessage): boolean {
 async function getMessageBroadcastLocalStoreName(): Promise<string | null> {
   const userToken = await getHashedUserToken();
   if (!userToken) return null;
-  return `${broadcastsLocalStoreName}.${userToken}`;
+  return `${STORAGE_KEYS.messageBroadcasts}.${userToken}`;
 }
 
 function getNumberOfTimesShownLocalStoreName(

--- a/src/managers/message-user-queue-manager.test.ts
+++ b/src/managers/message-user-queue-manager.test.ts
@@ -23,6 +23,9 @@ vi.mock('../utilities/local-storage', () => ({
   setKeyToLocalStore: vi.fn(),
   getKeyFromLocalStore: vi.fn(() => null),
   clearKeyFromLocalStore: vi.fn(),
+  STORAGE_KEYS: {
+    messageUser: 'gist.web.message.user',
+  },
 }));
 vi.mock('./user-manager', () => ({
   getHashedUserToken: vi.fn(() => Promise.resolve('hashed-token')),

--- a/src/managers/message-user-queue-manager.ts
+++ b/src/managers/message-user-queue-manager.ts
@@ -2,12 +2,12 @@ import {
   getKeyFromLocalStore,
   setKeyToLocalStore,
   clearKeyFromLocalStore,
+  STORAGE_KEYS,
 } from '../utilities/local-storage';
 import { getHashedUserToken } from './user-manager';
 import { log } from '../utilities/log';
 import type { GistMessage, DisplaySettings } from '../types';
 
-const messageQueueLocalStoreName = 'gist.web.message.user';
 const messagesLocalStoreCacheInMinutes = 60;
 
 export async function updateQueueLocalStore(messages: GistMessage[]): Promise<void> {
@@ -73,25 +73,25 @@ async function getSeenMessagesFromLocalStore(): Promise<string[]> {
 async function getUserQueueLocalStoreName(): Promise<string | null> {
   const userToken = await getHashedUserToken();
   if (!userToken) return null;
-  return `${messageQueueLocalStoreName}.${userToken}`;
+  return `${STORAGE_KEYS.messageUser}.${userToken}`;
 }
 
 async function getUserSeenQueueLocalStoreName(): Promise<string | null> {
   const userToken = await getHashedUserToken();
   if (!userToken) return null;
-  return `${messageQueueLocalStoreName}.${userToken}.seen`;
+  return `${STORAGE_KEYS.messageUser}.${userToken}.seen`;
 }
 
 async function getMessageLoadingStateLocalStoreName(queueId: string): Promise<string | null> {
   const userToken = await getHashedUserToken();
   if (!userToken) return null;
-  return `${messageQueueLocalStoreName}.${userToken}.message.${queueId}.loading`;
+  return `${STORAGE_KEYS.messageUser}.${userToken}.message.${queueId}.loading`;
 }
 
 async function getMessageStateLocalStoreName(queueId: string): Promise<string | null> {
   const userToken = await getHashedUserToken();
   if (!userToken) return null;
-  return `${messageQueueLocalStoreName}.${userToken}.message.${queueId}.state`;
+  return `${STORAGE_KEYS.messageUser}.${userToken}.message.${queueId}.state`;
 }
 
 export async function saveMessageState(

--- a/src/managers/preview-bar-manager.ts
+++ b/src/managers/preview-bar-manager.ts
@@ -12,8 +12,8 @@ import { findElement } from '../utilities/dom';
 import { PREVIEW_BAR_CSS, chevronSvg } from './preview-bar-styles';
 import { savePreviewDisplaySettings, deletePreviewSession } from '../services/preview-service';
 import { PREVIEW_PARAM_ID, teardownPreview } from '../utilities/preview-mode';
+import { STORAGE_KEYS } from '../utilities/local-storage';
 
-const STORAGE_KEY = 'gist.previewBar.collapsed';
 const STYLE_ID = 'gist-pb-styles';
 const BAR_ID = 'gist-preview-bar';
 
@@ -752,7 +752,7 @@ function cancelSessionEnd() {
 function toggleCollapse() {
   isCollapsed = !isCollapsed;
   try {
-    sessionStorage.setItem(STORAGE_KEY, String(isCollapsed));
+    sessionStorage.setItem(STORAGE_KEYS.previewBarCollapsed, String(isCollapsed));
   } catch {
     /* ignore */
   }
@@ -765,7 +765,7 @@ export function initPreviewBar(): void {
   if (document.getElementById(BAR_ID)) return;
   injectStyles();
   try {
-    isCollapsed = sessionStorage.getItem(STORAGE_KEY) === 'true';
+    isCollapsed = sessionStorage.getItem(STORAGE_KEYS.previewBarCollapsed) === 'true';
   } catch {
     isCollapsed = false;
   }

--- a/src/managers/queue-manager.test.ts
+++ b/src/managers/queue-manager.test.ts
@@ -22,7 +22,6 @@ vi.mock('./user-manager', () => ({
 vi.mock('../services/queue-service', () => ({
   getUserQueue: vi.fn(),
   getQueueSSEEndpoint: vi.fn(() => null),
-  userQueueNextPullCheckLocalStoreName: 'gist.web.userQueueNextPullCheck',
 }));
 vi.mock('./message-manager', () => ({
   showMessage: vi.fn(() => Promise.resolve(null)),
@@ -48,6 +47,9 @@ vi.mock('./gist-properties-manager', () => ({
 vi.mock('../utilities/local-storage', () => ({
   clearKeyFromLocalStore: vi.fn(),
   getKeyFromLocalStore: vi.fn(() => null),
+  STORAGE_KEYS: {
+    userQueueNextPullCheck: 'gist.web.userQueueNextPullCheck',
+  },
 }));
 vi.mock('./message-broadcast-manager', () => ({
   updateBroadcastsLocalStore: vi.fn(),

--- a/src/managers/queue-manager.ts
+++ b/src/managers/queue-manager.ts
@@ -1,15 +1,15 @@
 import Gist from '../gist';
 import { log } from '../utilities/log';
 import { getUserToken, isAnonymousUser } from './user-manager';
-import {
-  getUserQueue,
-  getQueueSSEEndpoint,
-  userQueueNextPullCheckLocalStoreName,
-} from '../services/queue-service';
+import { getUserQueue, getQueueSSEEndpoint } from '../services/queue-service';
 import { showMessage, embedMessage, resetMessage } from './message-manager';
 import { resolveMessageProperties } from './gist-properties-manager';
 import { positions } from './page-component-manager';
-import { clearKeyFromLocalStore, getKeyFromLocalStore } from '../utilities/local-storage';
+import {
+  clearKeyFromLocalStore,
+  getKeyFromLocalStore,
+  STORAGE_KEYS,
+} from '../utilities/local-storage';
 import {
   updateBroadcastsLocalStore,
   getEligibleBroadcasts,
@@ -184,7 +184,7 @@ export async function pullMessagesFromQueue(): Promise<void> {
 async function checkQueueThroughPolling(): Promise<void> {
   if (getUserToken()) {
     if (Gist.isDocumentVisible) {
-      if (getKeyFromLocalStore(userQueueNextPullCheckLocalStoreName) === null) {
+      if (getKeyFromLocalStore(STORAGE_KEYS.userQueueNextPullCheck) === null) {
         const response = await getUserQueue();
         if (response) {
           if (response.status === 200 || response.status === 204) {
@@ -245,7 +245,7 @@ async function setupSSEQueueListener(): Promise<void> {
       log(`Failed to parse SSE settings: ${e}`);
     }
 
-    clearKeyFromLocalStore(userQueueNextPullCheckLocalStoreName);
+    clearKeyFromLocalStore(STORAGE_KEYS.userQueueNextPullCheck);
     await checkQueueThroughPolling();
   });
 

--- a/src/managers/user-manager.test.ts
+++ b/src/managers/user-manager.test.ts
@@ -19,9 +19,12 @@ vi.mock('../utilities/local-storage', () => ({
   setKeyToLocalStore: vi.fn(),
   getKeyFromLocalStore: vi.fn(() => null),
   clearKeyFromLocalStore: vi.fn(),
-}));
-vi.mock('../services/queue-service', () => ({
-  userQueueNextPullCheckLocalStoreName: 'gist.web.userQueueNextPullCheck',
+  STORAGE_KEYS: {
+    userToken: 'gist.web.userToken',
+    usingGuestUserToken: 'gist.web.usingGuestUserToken',
+    guestUserToken: 'gist.web.guestUserToken',
+    userQueueNextPullCheck: 'gist.web.userQueueNextPullCheck',
+  },
 }));
 vi.mock('uuid', () => ({
   v4: vi.fn(() => 'mock-uuid-1234'),

--- a/src/managers/user-manager.ts
+++ b/src/managers/user-manager.ts
@@ -4,20 +4,17 @@ import {
   setKeyToLocalStore,
   getKeyFromLocalStore,
   clearKeyFromLocalStore,
+  STORAGE_KEYS,
 } from '../utilities/local-storage';
-import { userQueueNextPullCheckLocalStoreName } from '../services/queue-service';
 
-const userTokenLocalStoreName = 'gist.web.userToken';
-const usingGuestUserTokenLocalStoreName = 'gist.web.usingGuestUserToken';
-const guestUserTokenLocalStoreName = 'gist.web.guestUserToken';
 const defaultExpiryInDays = 30;
 
 export function isUsingGuestUserToken(): boolean {
-  return getKeyFromLocalStore(usingGuestUserTokenLocalStoreName) !== null;
+  return getKeyFromLocalStore(STORAGE_KEYS.usingGuestUserToken) !== null;
 }
 
 export function getUserToken(): string | null {
-  return getKeyFromLocalStore(userTokenLocalStoreName) as string | null;
+  return getKeyFromLocalStore(STORAGE_KEYS.userToken) as string | null;
 }
 
 export function setUserToken(userToken: string, expiryDate?: Date): void {
@@ -25,12 +22,12 @@ export function setUserToken(userToken: string, expiryDate?: Date): void {
     expiryDate = new Date();
     expiryDate.setDate(expiryDate.getDate() + defaultExpiryInDays);
   }
-  setKeyToLocalStore(userTokenLocalStoreName, userToken, expiryDate);
+  setKeyToLocalStore(STORAGE_KEYS.userToken, userToken, expiryDate);
 
   if (isUsingGuestUserToken()) {
     // Removing pull check time key so that we check the queue immediately after the userToken is set.
-    clearKeyFromLocalStore(userQueueNextPullCheckLocalStoreName);
-    clearKeyFromLocalStore(usingGuestUserTokenLocalStoreName);
+    clearKeyFromLocalStore(STORAGE_KEYS.userQueueNextPullCheck);
+    clearKeyFromLocalStore(STORAGE_KEYS.usingGuestUserToken);
   }
   log(`Set user token "${userToken}" with expiry date set to ${expiryDate}`);
 }
@@ -38,15 +35,15 @@ export function setUserToken(userToken: string, expiryDate?: Date): void {
 export function useGuestSession(): void {
   // Guest sessions should never override existing sessions
   if (getUserToken() === null) {
-    let guestUserToken = getKeyFromLocalStore(guestUserTokenLocalStoreName) as string | null;
+    let guestUserToken = getKeyFromLocalStore(STORAGE_KEYS.guestUserToken) as string | null;
     if (guestUserToken == null) {
       guestUserToken = uuidv4();
-      setKeyToLocalStore(guestUserTokenLocalStoreName, guestUserToken);
+      setKeyToLocalStore(STORAGE_KEYS.guestUserToken, guestUserToken);
       log(`Set guest user token "${guestUserToken}" with expiry date set to 1 year from today`);
     }
 
-    setKeyToLocalStore(userTokenLocalStoreName, guestUserToken);
-    setKeyToLocalStore(usingGuestUserTokenLocalStoreName, true);
+    setKeyToLocalStore(STORAGE_KEYS.userToken, guestUserToken);
+    setKeyToLocalStore(STORAGE_KEYS.usingGuestUserToken, true);
     log(`Using anonymous session with token: "${guestUserToken}"`);
   }
 }
@@ -72,7 +69,7 @@ export function getEncodedUserToken(): string | null {
 }
 
 export function clearUserToken(): void {
-  clearKeyFromLocalStore(userTokenLocalStoreName);
+  clearKeyFromLocalStore(STORAGE_KEYS.userToken);
   log(`Cleared user token`);
 }
 

--- a/src/services/queue-service.test.ts
+++ b/src/services/queue-service.test.ts
@@ -1,13 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import {
-  getUserQueue,
-  getQueueSSEEndpoint,
-  userQueueNextPullCheckLocalStoreName,
-} from './queue-service';
+import { getUserQueue, getQueueSSEEndpoint } from './queue-service';
 import {
   getKeyFromLocalStore,
   setKeyToLocalStore,
   shouldPersistSession,
+  STORAGE_KEYS,
 } from '../utilities/local-storage';
 import { getEncodedUserToken, getUserToken } from '../managers/user-manager';
 
@@ -127,7 +124,7 @@ describe('queue-service', () => {
 
     await getUserQueue();
 
-    expect(getKeyFromLocalStore(userQueueNextPullCheckLocalStoreName)).toBeNull();
+    expect(getKeyFromLocalStore(STORAGE_KEYS.userQueueNextPullCheck)).toBeNull();
   });
 
   it('getQueueSSEEndpoint() returns null when no user token', async () => {
@@ -161,7 +158,7 @@ describe('queue-service', () => {
 
     await getUserQueue();
 
-    const storedValue = getKeyFromLocalStore(userQueueNextPullCheckLocalStoreName);
+    const storedValue = getKeyFromLocalStore(STORAGE_KEYS.userQueueNextPullCheck);
     expect(Number(storedValue)).toBe(120);
   });
 });

--- a/src/services/queue-service.test.ts
+++ b/src/services/queue-service.test.ts
@@ -137,7 +137,7 @@ describe('queue-service', () => {
 
   it('getQueueSSEEndpoint() returns correct URL with encoded token and site ID', () => {
     vi.mocked(getEncodedUserToken).mockReturnValue('encoded-token-123');
-    setKeyToLocalStore('gist.web.sessionId', 'session-456', new Date(Date.now() + 1800000));
+    setKeyToLocalStore(STORAGE_KEYS.sessionId, 'session-456', new Date(Date.now() + 1800000));
 
     const result = getQueueSSEEndpoint();
 

--- a/src/services/queue-service.ts
+++ b/src/services/queue-service.ts
@@ -4,6 +4,7 @@ import {
   getKeyFromLocalStore,
   setKeyToLocalStore,
   clearKeyFromLocalStore,
+  STORAGE_KEYS,
 } from '../utilities/local-storage';
 import { log } from '../utilities/log';
 import { isUsingGuestUserToken, getEncodedUserToken, getUserToken } from '../managers/user-manager';
@@ -19,9 +20,6 @@ const msPerSecond = 1000;
 
 let currentPollingDelayInSeconds = defaultPollingDelayInSeconds;
 let checkInProgress = false;
-
-export const userQueueNextPullCheckLocalStoreName = 'gist.web.userQueueNextPullCheck';
-export const sessionIdLocalStoreName = 'gist.web.sessionId';
 
 export async function getUserQueue(): Promise<NetworkResponse | undefined> {
   const existingUserToken = getUserToken();
@@ -52,7 +50,7 @@ export async function getUserQueue(): Promise<NetworkResponse | undefined> {
 
   if (existingUserToken !== getUserToken()) {
     log('User token changed, clearing queue next pull check.');
-    clearKeyFromLocalStore(userQueueNextPullCheckLocalStoreName);
+    clearKeyFromLocalStore(STORAGE_KEYS.userQueueNextPullCheck);
     return;
   }
 
@@ -67,12 +65,12 @@ function setQueueUseSSE(response?: NetworkResponse): void {
 }
 
 function getSessionId(): string {
-  let sessionId = getKeyFromLocalStore(sessionIdLocalStoreName) as string | null;
+  let sessionId = getKeyFromLocalStore(STORAGE_KEYS.sessionId) as string | null;
   if (!sessionId) {
     sessionId = uuidv4();
   }
   setKeyToLocalStore(
-    sessionIdLocalStoreName,
+    STORAGE_KEYS.sessionId,
     sessionId,
     new Date(new Date().getTime() + sessionExpiryMs)
   );
@@ -87,11 +85,7 @@ function scheduleNextQueuePull(response?: NetworkResponse): void {
     }
   }
   const expiryDate = new Date(new Date().getTime() + currentPollingDelayInSeconds * msPerSecond);
-  setKeyToLocalStore(
-    userQueueNextPullCheckLocalStoreName,
-    currentPollingDelayInSeconds,
-    expiryDate
-  );
+  setKeyToLocalStore(STORAGE_KEYS.userQueueNextPullCheck, currentPollingDelayInSeconds, expiryDate);
 }
 
 export function getQueueSSEEndpoint(): string | null {

--- a/src/services/settings.ts
+++ b/src/services/settings.ts
@@ -2,13 +2,12 @@ import {
   getKeyFromLocalStore,
   setKeyToLocalStore,
   clearKeyFromLocalStore,
+  STORAGE_KEYS,
 } from '../utilities/local-storage';
 import { log } from '../utilities/log';
 import { v4 as uuidv4 } from 'uuid';
 import type { GistEnv } from '../types';
 
-const userQueueUseSSELocalStoreName = 'gist.web.userQueueUseSSE';
-const userQueueActiveSSEConnectionLocalStoreName = 'gist.web.activeSSEConnection';
 const heartbeatSlop = 5;
 let sseHeartbeat = 30;
 let sdkId: string | undefined;
@@ -59,31 +58,31 @@ export const settings: Settings = {
     return sdkId as string;
   },
   useSSE(): boolean {
-    return (getKeyFromLocalStore(userQueueUseSSELocalStoreName) ?? false) as boolean;
+    return (getKeyFromLocalStore(STORAGE_KEYS.userQueueUseSSE) ?? false) as boolean;
   },
   setUseSSEFlag(useSSE: boolean): void {
     setKeyToLocalStore(
-      userQueueUseSSELocalStoreName,
+      STORAGE_KEYS.userQueueUseSSE,
       useSSE,
       new Date(new Date().getTime() + 60000)
     );
     log(`Set user uses SSE to "${useSSE}"`);
   },
   removeActiveSSEConnection(): void {
-    clearKeyFromLocalStore(userQueueActiveSSEConnectionLocalStoreName);
+    clearKeyFromLocalStore(STORAGE_KEYS.activeSSEConnection);
   },
   setActiveSSEConnection(): void {
     setKeyToLocalStore(
-      userQueueActiveSSEConnectionLocalStoreName,
+      STORAGE_KEYS.activeSSEConnection,
       settings.getSdkId(),
       new Date(new Date().getTime() + settings.getSSEHeartbeat())
     );
   },
   hasActiveSSEConnection(): unknown {
-    return getKeyFromLocalStore(userQueueActiveSSEConnectionLocalStoreName) ?? false;
+    return getKeyFromLocalStore(STORAGE_KEYS.activeSSEConnection) ?? false;
   },
   isSSEConnectionManagedBySDK(): boolean {
-    return getKeyFromLocalStore(userQueueActiveSSEConnectionLocalStoreName) === settings.getSdkId();
+    return getKeyFromLocalStore(STORAGE_KEYS.activeSSEConnection) === settings.getSdkId();
   },
   getSSEHeartbeat(): number {
     return (sseHeartbeat + heartbeatSlop) * 1000;

--- a/src/utilities/local-storage.ts
+++ b/src/utilities/local-storage.ts
@@ -1,7 +1,27 @@
 import { log } from './log';
 
 const maxExpiryDays = 365;
-const isPersistingSessionLocalStoreName = 'gist.web.isPersistingSession';
+
+export const STORAGE_KEYS: Record<string, string> = {
+  userToken: 'gist.web.userToken',
+  usingGuestUserToken: 'gist.web.usingGuestUserToken',
+  guestUserToken: 'gist.web.guestUserToken',
+  userQueueNextPullCheck: 'gist.web.userQueueNextPullCheck',
+  sessionId: 'gist.web.sessionId',
+  isPersistingSession: 'gist.web.isPersistingSession',
+  userQueueUseSSE: 'gist.web.userQueueUseSSE',
+  activeSSEConnection: 'gist.web.activeSSEConnection',
+  userLocale: 'gist.web.userLocale',
+  customAttributes: 'gist.web.customAttributes',
+
+  messageBroadcasts: 'gist.web.message.broadcasts',
+  messageUser: 'gist.web.message.user',
+  inboxMessages: 'gist.web.inbox.messages',
+
+  previewBarStep: 'gist.web.previewBarStep',
+  previewBarDisplayType: 'gist.web.previewBarDisplayType',
+  previewBarCollapsed: 'gist.previewBar.collapsed',
+};
 
 interface StoredItem {
   value: unknown;
@@ -9,10 +29,14 @@ interface StoredItem {
 }
 
 export function shouldPersistSession(persisted: boolean | string): void {
-  sessionStorage.setItem(isPersistingSessionLocalStoreName, String(persisted));
+  sessionStorage.setItem(STORAGE_KEYS.isPersistingSession, String(persisted));
 }
 
-export function setKeyToLocalStore(key: string, value: unknown, ttl: Date | null = null): void {
+export function setKeyToLocalStore(
+  key: keyof typeof STORAGE_KEYS,
+  value: unknown,
+  ttl: Date | null = null
+): void {
   let expiryDate = ttl;
   if (!expiryDate) {
     expiryDate = new Date();
@@ -25,11 +49,11 @@ export function setKeyToLocalStore(key: string, value: unknown, ttl: Date | null
   getStorage().setItem(key, JSON.stringify(item));
 }
 
-export function getKeyFromLocalStore(key: string): unknown | null {
+export function getKeyFromLocalStore(key: keyof typeof STORAGE_KEYS): unknown | null {
   return checkKeyForExpiry(key);
 }
 
-export function clearKeyFromLocalStore(key: string): void {
+export function clearKeyFromLocalStore(key: keyof typeof STORAGE_KEYS): void {
   getStorage().removeItem(key);
 }
 
@@ -37,7 +61,7 @@ export function clearExpiredFromLocalStore(): void {
   const storage = getStorage();
   for (let i = storage.length - 1; i >= 0; i--) {
     const key = storage.key(i);
-    if (key?.startsWith('gist.')) {
+    if (isGistKey(key)) {
       checkKeyForExpiry(key);
     }
   }
@@ -45,16 +69,16 @@ export function clearExpiredFromLocalStore(): void {
 
 export function clearSessionPersistenceFlag(): void {
   try {
-    sessionStorage.removeItem(isPersistingSessionLocalStoreName);
+    sessionStorage.removeItem(STORAGE_KEYS.isPersistingSession);
   } catch {
     /* ignore */
   }
 }
 
 export function isSessionBeingPersisted(): boolean {
-  const currentValue = sessionStorage.getItem(isPersistingSessionLocalStoreName);
+  const currentValue = sessionStorage.getItem(STORAGE_KEYS.isPersistingSession);
   if (currentValue === null) {
-    sessionStorage.setItem(isPersistingSessionLocalStoreName, 'true');
+    sessionStorage.setItem(STORAGE_KEYS.isPersistingSession, 'true');
     return true;
   }
   return currentValue === 'true';
@@ -64,7 +88,7 @@ function getStorage(): Storage {
   return isSessionBeingPersisted() ? localStorage : sessionStorage;
 }
 
-function checkKeyForExpiry(key: string | null): unknown | null {
+function checkKeyForExpiry(key: keyof typeof STORAGE_KEYS | string | null): unknown | null {
   if (!key) return null;
 
   try {
@@ -74,7 +98,7 @@ function checkKeyForExpiry(key: string | null): unknown | null {
     const item = JSON.parse(itemStr) as StoredItem;
     if (!item.expiry) return item.value;
 
-    if (key.startsWith('gist.')) {
+    if (isGistKey(key)) {
       const now = new Date();
       const expiryTime = new Date(item.expiry);
 
@@ -87,12 +111,12 @@ function checkKeyForExpiry(key: string | null): unknown | null {
           !key.endsWith('state'));
       const sixtyMinutesFromNow = new Date(now.getTime() + 61 * 60 * 1000);
       if (isBroadcastOrUserKey && expiryTime.getTime() > sixtyMinutesFromNow.getTime()) {
-        clearKeyFromLocalStore(key);
+        clearKeyFromLocalStore(key as keyof typeof STORAGE_KEYS);
         return null;
       }
 
       if (now.getTime() > expiryTime.getTime()) {
-        clearKeyFromLocalStore(key);
+        clearKeyFromLocalStore(key as keyof typeof STORAGE_KEYS);
         return null;
       }
     }
@@ -103,4 +127,8 @@ function checkKeyForExpiry(key: string | null): unknown | null {
   }
 
   return null;
+}
+
+function isGistKey(key: string | null): boolean {
+  return key?.startsWith('gist.') ?? false;
 }

--- a/src/utilities/local-storage.ts
+++ b/src/utilities/local-storage.ts
@@ -2,7 +2,7 @@ import { log } from './log';
 
 const maxExpiryDays = 365;
 
-export const STORAGE_KEYS: Record<string, string> = {
+export const STORAGE_KEYS = {
   userToken: 'gist.web.userToken',
   usingGuestUserToken: 'gist.web.usingGuestUserToken',
   guestUserToken: 'gist.web.guestUserToken',
@@ -19,9 +19,10 @@ export const STORAGE_KEYS: Record<string, string> = {
   inboxMessages: 'gist.web.inbox.messages',
 
   previewBarStep: 'gist.web.previewBarStep',
-  previewBarDisplayType: 'gist.web.previewBarDisplayType',
   previewBarCollapsed: 'gist.previewBar.collapsed',
 };
+
+export type StorageKey = (typeof STORAGE_KEYS)[keyof typeof STORAGE_KEYS];
 
 interface StoredItem {
   value: unknown;
@@ -33,7 +34,7 @@ export function shouldPersistSession(persisted: boolean | string): void {
 }
 
 export function setKeyToLocalStore(
-  key: keyof typeof STORAGE_KEYS,
+  key: StorageKey | string,
   value: unknown,
   ttl: Date | null = null
 ): void {
@@ -49,11 +50,11 @@ export function setKeyToLocalStore(
   getStorage().setItem(key, JSON.stringify(item));
 }
 
-export function getKeyFromLocalStore(key: keyof typeof STORAGE_KEYS): unknown | null {
+export function getKeyFromLocalStore(key: StorageKey | string): unknown | null {
   return checkKeyForExpiry(key);
 }
 
-export function clearKeyFromLocalStore(key: keyof typeof STORAGE_KEYS): void {
+export function clearKeyFromLocalStore(key: StorageKey | string): void {
   getStorage().removeItem(key);
 }
 
@@ -88,7 +89,7 @@ function getStorage(): Storage {
   return isSessionBeingPersisted() ? localStorage : sessionStorage;
 }
 
-function checkKeyForExpiry(key: keyof typeof STORAGE_KEYS | string | null): unknown | null {
+function checkKeyForExpiry(key: string | null): unknown | null {
   if (!key) return null;
 
   try {
@@ -111,12 +112,12 @@ function checkKeyForExpiry(key: keyof typeof STORAGE_KEYS | string | null): unkn
           !key.endsWith('state'));
       const sixtyMinutesFromNow = new Date(now.getTime() + 61 * 60 * 1000);
       if (isBroadcastOrUserKey && expiryTime.getTime() > sixtyMinutesFromNow.getTime()) {
-        clearKeyFromLocalStore(key as keyof typeof STORAGE_KEYS);
+        clearKeyFromLocalStore(key);
         return null;
       }
 
       if (now.getTime() > expiryTime.getTime()) {
-        clearKeyFromLocalStore(key as keyof typeof STORAGE_KEYS);
+        clearKeyFromLocalStore(key);
         return null;
       }
     }


### PR DESCRIPTION
Consolidating storage key definitions into central location and typing helper functions to maintain consistency.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad refactor across queue/user/message managers to use centralized `STORAGE_KEYS`; a wrong key mapping would break persisted state (tokens, queue polling, SSE flags), though key strings themselves remain unchanged.
> 
> **Overview**
> **Consolidates browser storage key usage** by introducing a shared `STORAGE_KEYS` map in `local-storage.ts` and updating managers/services to reference it instead of duplicating string constants.
> 
> `local-storage` helpers are now typed to accept `StorageKey | string`, and expiry cleanup uses a small `isGistKey` helper. Tests were updated to mock `STORAGE_KEYS` accordingly, and `queue-service` no longer exports storage-key constants (callers now use `STORAGE_KEYS` directly).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24016533c7807d8a4cc0e4575f99f8e4ed7c8a85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->