### PR TITLE
Environment based renderer host settings

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -152,6 +152,7 @@
               <select id="env" name="env">
                 <option value="prod">prod</option>
                 <option value="dev">dev</option>
+                <option value="local">local</option>
               </select>
             </div>
             <div class="form-field">

--- a/src/managers/message-manager.test.ts
+++ b/src/managers/message-manager.test.ts
@@ -28,7 +28,11 @@ vi.mock('../services/log-service', () => ({
 vi.mock('uuid', () => ({ v4: vi.fn(() => 'mock-uuid') }));
 vi.mock('../services/settings', () => ({
   settings: {
-    RENDERER_HOST: 'https://renderer.test',
+    RENDERER_HOST: {
+      prod: 'https://renderer.test',
+      dev: 'https://renderer.test',
+      local: 'http://localhost',
+    },
     ENGINE_API_ENDPOINT: {
       prod: 'https://api.test',
       dev: 'https://api.test',

--- a/src/managers/message-manager.ts
+++ b/src/managers/message-manager.ts
@@ -340,8 +340,9 @@ function handleTouchStartEvents(): void {
 }
 
 async function handleGistEvents(e: MessageEvent): Promise<void> {
+  const env = Gist.config.env as keyof typeof settings.RENDERER_HOST;
   const data = e.data as GistEventData;
-  if (data.gist && e.origin === settings.RENDERER_HOST) {
+  if (data.gist && e.origin === settings.RENDERER_HOST[env]) {
     const currentInstanceId = data.gist.instanceId;
     const currentMessage = fetchMessageByInstanceId(currentInstanceId);
     if (!currentMessage) {

--- a/src/managers/queue-manager.test.ts
+++ b/src/managers/queue-manager.test.ts
@@ -74,7 +74,11 @@ vi.mock('../services/settings', () => ({
     setUseSSEFlag: vi.fn(),
     setSSEHeartbeat: vi.fn(),
     getSSEHeartbeat: vi.fn(() => 30),
-    RENDERER_HOST: 'https://renderer.test',
+    RENDERER_HOST: {
+      prod: 'https://renderer.test',
+      dev: 'https://renderer.test',
+      local: 'http://localhost',
+    },
     ENGINE_API_ENDPOINT: {
       prod: 'https://api.test',
       dev: 'https://api.test',

--- a/src/services/settings.ts
+++ b/src/services/settings.ts
@@ -14,7 +14,7 @@ let sseHeartbeat = 30;
 let sdkId: string | undefined;
 
 export interface Settings {
-  RENDERER_HOST: string;
+  RENDERER_HOST: Record<GistEnv, string>;
   ENGINE_API_ENDPOINT: Record<GistEnv, string>;
   GIST_QUEUE_API_ENDPOINT: Record<GistEnv, string>;
   GIST_QUEUE_REALTIME_API_ENDPOINT: Record<GistEnv, string>;
@@ -31,7 +31,11 @@ export interface Settings {
 }
 
 export const settings: Settings = {
-  RENDERER_HOST: 'https://code.gist.build',
+  RENDERER_HOST: {
+    prod: 'https://code.gist.build',
+    dev: 'https://code.gist.build',
+    local: 'http://localhost:9998',
+  },
   ENGINE_API_ENDPOINT: {
     prod: 'https://engine.api.gist.build',
     dev: 'https://engine.api.dev.gist.build',
@@ -50,7 +54,7 @@ export const settings: Settings = {
   GIST_VIEW_ENDPOINT: {
     prod: 'https://renderer.gist.build/3.0',
     dev: 'https://renderer.gist.build/3.0',
-    local: 'http://app.local.gist.build:8080/web',
+    local: 'http://localhost:9998',
   },
   getSdkId(): string {
     if (!sdkId) {

--- a/src/services/settings.ts
+++ b/src/services/settings.ts
@@ -44,12 +44,12 @@ export const settings: Settings = {
   GIST_QUEUE_API_ENDPOINT: {
     prod: 'https://consumer.cloud.gist.build',
     dev: 'https://consumer.cloud.dev.gist.build',
-    local: 'http://api.local.gist.build:86',
+    local: 'http://localhost:3010',
   },
   GIST_QUEUE_REALTIME_API_ENDPOINT: {
     prod: 'https://realtime.cloud.gist.build',
     dev: 'https://realtime.cloud.dev.gist.build',
-    local: 'http://api.local.gist.build:3000',
+    local: 'http://localhost:3009',
   },
   GIST_VIEW_ENDPOINT: {
     prod: 'https://renderer.gist.build/3.0',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches cross-origin message validation and environment routing for renderer communication; a misconfigured `env`/host map could block iframe events or allow unexpected origins in non-prod setups.
> 
> **Overview**
> Updates `settings.RENDERER_HOST` from a single string to an environment-keyed map (`prod`/`dev`/`local`), and switches `message-manager`’s postMessage origin validation to check `settings.RENDERER_HOST[env]` based on `Gist.config.env`.
> 
> Adjusts local development URLs in `settings` (queue/realtime/view/renderer) to use `localhost` ports, updates related unit test mocks to match the new `RENDERER_HOST` shape, and adds a `local` environment option in `examples/index.html`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d43e3ebdb7262c9bde1a1384a87d48ea5c966d41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->