### PR TITLE
Add error isolation and snapshot iteration to EventEmitter dispatch

### DIFF
--- a/src/utilities/event-emitter.test.ts
+++ b/src/utilities/event-emitter.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect, vi } from 'vitest';
 import EventEmitter from './event-emitter';
 
 describe('EventEmitter', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('on() registers a callback and dispatch() calls it with the event', () => {
     const emitter = new EventEmitter();
     const callback = vi.fn();
@@ -49,5 +53,72 @@ describe('EventEmitter', () => {
   it('dispatch() on an event with no listeners does nothing (no error)', () => {
     const emitter = new EventEmitter();
     expect(() => emitter.dispatch('nonexistent', 'event')).not.toThrow();
+  });
+
+  it('a throwing callback does not prevent other callbacks from firing', () => {
+    const emitter = new EventEmitter();
+    const cb1 = vi.fn(() => {
+      throw new Error('cb1 exploded');
+    });
+    const cb2 = vi.fn();
+    emitter.on('test', cb1);
+    emitter.on('test', cb2);
+
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    emitter.dispatch('test', 'event');
+
+    expect(cb2).toHaveBeenCalledWith('event');
+  });
+
+  it('multiple throwing callbacks each log a warning and do not break the chain', () => {
+    const emitter = new EventEmitter();
+    const error1 = new Error('first');
+    const error2 = new Error('second');
+    const cb1 = vi.fn(() => {
+      throw error1;
+    });
+    const cb2 = vi.fn(() => {
+      throw error2;
+    });
+    const cb3 = vi.fn();
+    emitter.on('test', cb1);
+    emitter.on('test', cb2);
+    emitter.on('test', cb3);
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    emitter.dispatch('test', 'event');
+
+    expect(cb3).toHaveBeenCalledWith('event');
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    expect(warnSpy).toHaveBeenCalledWith('[Gist] Error in "test" event listener:', error1);
+    expect(warnSpy).toHaveBeenCalledWith('[Gist] Error in "test" event listener:', error2);
+  });
+
+  it('a throwing callback logs a warning to console', () => {
+    const emitter = new EventEmitter();
+    const error = new Error('listener failed');
+    emitter.on('test', () => {
+      throw error;
+    });
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    emitter.dispatch('test', 'event');
+
+    expect(warnSpy).toHaveBeenCalledWith('[Gist] Error in "test" event listener:', error);
+  });
+
+  it('dispatch iterates over a snapshot so removing a listener during dispatch is safe', () => {
+    const emitter = new EventEmitter();
+    const cb1 = vi.fn(() => {
+      emitter.off('test', cb2);
+    });
+    const cb2 = vi.fn();
+    emitter.on('test', cb1);
+    emitter.on('test', cb2);
+
+    emitter.dispatch('test', 'event');
+
+    expect(cb1).toHaveBeenCalledWith('event');
+    expect(cb2).toHaveBeenCalledWith('event');
   });
 });

--- a/src/utilities/event-emitter.test.ts
+++ b/src/utilities/event-emitter.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import EventEmitter from './event-emitter';
 
 describe('EventEmitter', () => {

--- a/src/utilities/event-emitter.ts
+++ b/src/utilities/event-emitter.ts
@@ -34,7 +34,13 @@ export default class EventEmitter {
   dispatch(name: string, event: unknown): void {
     const callbacks = this.callbacks[name];
     if (callbacks) {
-      callbacks.forEach((cb) => cb(event));
+      [...callbacks].forEach((cb) => {
+        try {
+          cb(event);
+        } catch (e) {
+          console.warn(`[Gist] Error in "${name}" event listener:`, e);
+        }
+      });
     }
   }
 }


### PR DESCRIPTION
## Problem

The `EventEmitter.dispatch()` method iterates callbacks using `forEach`. If any callback throws an error, JavaScript halts the loop and all subsequent listeners for that event are silently skipped.

```typescript
// Before — one throw kills the rest
callbacks.forEach((cb) => cb(event));
```

The SDK exposes `Gist.events` publicly. Consumers register callbacks for events like `messageShown`, `messageDismissed`, and `eventDispatched`. A single misbehaving consumer callback can break the SDK's own internal listeners or other consumers' callbacks from ever firing.

## Solution

Wrap each callback invocation in a try/catch inside `dispatch()`. Errors are logged via `console.warn` (always visible, regardless of `Gist.config.logging`) with the event name for debuggability. This matches how the browser's native `EventTarget.dispatchEvent()` behaves — if a listener throws, the rest still fire.

```typescript
[...callbacks].forEach((cb) => {
  try {
    cb(event);
  } catch (e) {
    console.warn(`[Gist] Error in "${name}" event listener:`, e);
  }
});
```

## Snapshot Iteration (separate fix)

This PR also introduces snapshot iteration (`[...callbacks]`) to guard against a **mutation-during-iteration bug** in the original code. Previously, if a listener called `emitter.off()` on another listener during dispatch, `Array.splice()` inside `off()` would shift indexes and silently skip callbacks. Iterating over a shallow copy ensures all listeners registered at the time of dispatch are called, regardless of mid-dispatch mutations.

## Tests Added

- A throwing callback does not prevent other callbacks from firing
- Multiple consecutive throwing callbacks each log a warning and don't break the chain
- A throwing callback logs a `console.warn` with the event name and error
- Removing a listener during dispatch is safe (snapshot iteration)
- Added `afterEach(() => vi.restoreAllMocks())` for proper spy cleanup

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes runtime behavior of the public event system by swallowing listener exceptions and always warning, which could mask failures or add noisy logs; it also alters dispatch ordering semantics when listeners mutate subscriptions mid-dispatch.
> 
> **Overview**
> **Hardens `EventEmitter.dispatch()` against misbehaving listeners.** Dispatch now iterates over a snapshot (`[...callbacks]`) and wraps each callback in `try/catch`, so one throwing listener (or removing listeners mid-dispatch) no longer prevents remaining listeners from running.
> 
> **Adds test coverage for the new guarantees.** New Vitest cases assert that exceptions don’t break the chain, that `console.warn` is emitted (including multiple warnings), and that unsubscribing during dispatch is safe; tests also restore mocks via `afterEach`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3db88fdd40af0d77a047ba15ba77e7ba9f67e53c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->