### PR TITLE
Fix route rule evaluation to handle inconsistent currentRoute values

### DIFF
--- a/src/managers/queue-manager.test.ts
+++ b/src/managers/queue-manager.test.ts
@@ -267,4 +267,449 @@ describe('queue-manager', () => {
       expect(showMessage).not.toHaveBeenCalled();
     });
   });
+
+  describe('handleMessage – route rules', () => {
+    const defaultProperties = {
+      isEmbedded: false,
+      elementId: '',
+      hasRouteRule: false,
+      routeRule: '',
+      position: '',
+      hasPosition: false,
+      tooltipPosition: '',
+      hasTooltipPosition: false,
+      tooltipArrowColor: '#fff',
+      shouldScale: false,
+      campaignId: null,
+      messageWidth: 414,
+      overlayColor: '#00000033',
+      persistent: false,
+      exitClick: false,
+      hasCustomWidth: false,
+    };
+
+    const message: GistMessage = {
+      messageId: 'route-test-msg',
+      queueId: 'q-route',
+    };
+
+    function withRouteRule(routeRule: string) {
+      vi.mocked(resolveMessageProperties).mockReturnValue({
+        ...defaultProperties,
+        hasRouteRule: true,
+        routeRule,
+      });
+    }
+
+    function navigateTo(path: string) {
+      window.history.pushState({}, '', path);
+    }
+
+    beforeEach(() => {
+      (Gist as unknown as Record<string, unknown>).currentRoute = null;
+      (Gist as unknown as Record<string, unknown>).config = {};
+      navigateTo('/');
+    });
+
+    // --- No rules ---
+
+    it('shows message when no route rule is set', async () => {
+      vi.mocked(resolveMessageProperties).mockReturnValue(defaultProperties);
+      navigateTo('/any-page');
+
+      const result = await handleMessage(message);
+
+      expect(result).toBe(false); // false because showMessage mock returns null
+      expect(showMessage).toHaveBeenCalledWith(message);
+    });
+
+    // --- Contains rules (.*value.*) ---
+
+    it('shows message when "contains" rule matches pathname', async () => {
+      withRouteRule('^(.*\\/dashboard.*)$');
+      navigateTo('/dashboard');
+
+      await handleMessage(message);
+
+      expect(showMessage).toHaveBeenCalledWith(message);
+    });
+
+    it('shows message when "contains" rule matches nested pathname', async () => {
+      withRouteRule('^(.*\\/dashboard.*)$');
+      navigateTo('/dashboard/settings/billing');
+
+      await handleMessage(message);
+
+      expect(showMessage).toHaveBeenCalledWith(message);
+    });
+
+    it('shows message when "contains" rule matches pathname with prefix', async () => {
+      withRouteRule('^(.*\\/dashboard.*)$');
+      navigateTo('/app/dashboard');
+
+      await handleMessage(message);
+
+      expect(showMessage).toHaveBeenCalledWith(message);
+    });
+
+    it('blocks message when "contains" rule does not match pathname', async () => {
+      withRouteRule('^(.*\\/dashboard.*)$');
+      navigateTo('/pricing');
+
+      const result = await handleMessage(message);
+
+      expect(result).toBe(false);
+      expect(showMessage).not.toHaveBeenCalled();
+    });
+
+    // --- Equals rules (exact match) ---
+
+    it('shows message when "equals" rule matches pathname exactly', async () => {
+      withRouteRule('^(\\/pricing)$');
+      navigateTo('/pricing');
+
+      await handleMessage(message);
+
+      expect(showMessage).toHaveBeenCalledWith(message);
+    });
+
+    it('blocks message when "equals" rule does not match longer pathname', async () => {
+      withRouteRule('^(\\/pricing)$');
+      navigateTo('/pricing/enterprise');
+
+      const result = await handleMessage(message);
+
+      expect(result).toBe(false);
+      expect(showMessage).not.toHaveBeenCalled();
+    });
+
+    it('blocks message when "equals" rule does not match different pathname', async () => {
+      withRouteRule('^(\\/pricing)$');
+      navigateTo('/about');
+
+      const result = await handleMessage(message);
+
+      expect(result).toBe(false);
+      expect(showMessage).not.toHaveBeenCalled();
+    });
+
+    // --- Multiple OR rules (include logic) ---
+
+    it('shows message when first of multiple OR rules matches', async () => {
+      withRouteRule('^((.*\\/dashboard.*)|(\\/pricing))$');
+      navigateTo('/dashboard');
+
+      await handleMessage(message);
+
+      expect(showMessage).toHaveBeenCalledWith(message);
+    });
+
+    it('shows message when second of multiple OR rules matches', async () => {
+      withRouteRule('^((.*\\/dashboard.*)|(\\/pricing))$');
+      navigateTo('/pricing');
+
+      await handleMessage(message);
+
+      expect(showMessage).toHaveBeenCalledWith(message);
+    });
+
+    it('blocks message when no OR rules match', async () => {
+      withRouteRule('^((.*\\/dashboard.*)|(\\/pricing))$');
+      navigateTo('/about');
+
+      const result = await handleMessage(message);
+
+      expect(result).toBe(false);
+      expect(showMessage).not.toHaveBeenCalled();
+    });
+
+    // --- DO_NOT_DISPLAY_REGEX (platform blocking) ---
+
+    it('blocks message with DO_NOT_DISPLAY_REGEX', async () => {
+      withRouteRule('^DO_NOT_DISPLAY_IN_APP$');
+      navigateTo('/dashboard');
+
+      const result = await handleMessage(message);
+
+      expect(result).toBe(false);
+      expect(showMessage).not.toHaveBeenCalled();
+    });
+
+    it('blocks message with DO_NOT_DISPLAY_REGEX on root path', async () => {
+      withRouteRule('^DO_NOT_DISPLAY_IN_APP$');
+      navigateTo('/');
+
+      const result = await handleMessage(message);
+
+      expect(result).toBe(false);
+      expect(showMessage).not.toHaveBeenCalled();
+    });
+
+    // --- Root and special paths ---
+
+    it('shows message when rule matches root path', async () => {
+      withRouteRule('^(\\/)$');
+      navigateTo('/');
+
+      await handleMessage(message);
+
+      expect(showMessage).toHaveBeenCalledWith(message);
+    });
+
+    it('blocks message when root-only rule does not match other paths', async () => {
+      withRouteRule('^(\\/)$');
+      navigateTo('/dashboard');
+
+      const result = await handleMessage(message);
+
+      expect(result).toBe(false);
+      expect(showMessage).not.toHaveBeenCalled();
+    });
+
+    it('shows message when rule matches deeply nested path', async () => {
+      withRouteRule('^(.*\\/settings\\/billing.*)$');
+      navigateTo('/app/settings/billing/invoices');
+
+      await handleMessage(message);
+
+      expect(showMessage).toHaveBeenCalledWith(message);
+    });
+
+    // --- Exclude rules (negative lookahead) ---
+
+    it('shows message when exclude rule does not match', async () => {
+      // Include /dashboard but exclude /admin paths
+      withRouteRule('^(?!.*\\/admin)(.*\\/dashboard.*)$');
+      navigateTo('/dashboard');
+
+      await handleMessage(message);
+
+      expect(showMessage).toHaveBeenCalledWith(message);
+    });
+
+    it('blocks message when exclude rule matches', async () => {
+      withRouteRule('^(?!.*\\/admin)(.*\\/dashboard.*)$');
+      navigateTo('/admin/dashboard');
+
+      const result = await handleMessage(message);
+
+      expect(result).toBe(false);
+      expect(showMessage).not.toHaveBeenCalled();
+    });
+
+    // --- currentRoute backward compatibility ---
+
+    describe('currentRoute fallback', () => {
+      it('shows message when pathname does not match but currentRoute does', async () => {
+        withRouteRule('^(Dashboard)$');
+        navigateTo('/home');
+        (Gist as unknown as Record<string, unknown>).currentRoute = 'Dashboard';
+
+        await handleMessage(message);
+
+        expect(showMessage).toHaveBeenCalledWith(message);
+      });
+
+      it('blocks message when neither pathname nor currentRoute matches', async () => {
+        withRouteRule('^(Dashboard)$');
+        navigateTo('/home');
+        (Gist as unknown as Record<string, unknown>).currentRoute = 'Settings';
+
+        const result = await handleMessage(message);
+
+        expect(result).toBe(false);
+        expect(showMessage).not.toHaveBeenCalled();
+      });
+
+      it('does not use currentRoute fallback when currentRoute equals pathname', async () => {
+        withRouteRule('^(\\/dashboard)$');
+        navigateTo('/dashboard');
+        (Gist as unknown as Record<string, unknown>).currentRoute = '/dashboard';
+
+        await handleMessage(message);
+
+        // Still shows because pathname matches directly
+        expect(showMessage).toHaveBeenCalledWith(message);
+      });
+
+      it('shows message when currentRoute is null and pathname matches', async () => {
+        withRouteRule('^(.*\\/dashboard.*)$');
+        navigateTo('/dashboard');
+        (Gist as unknown as Record<string, unknown>).currentRoute = null;
+
+        await handleMessage(message);
+
+        expect(showMessage).toHaveBeenCalledWith(message);
+      });
+
+      it('blocks message when currentRoute is null and pathname does not match', async () => {
+        withRouteRule('^(.*\\/dashboard.*)$');
+        navigateTo('/pricing');
+        (Gist as unknown as Record<string, unknown>).currentRoute = null;
+
+        const result = await handleMessage(message);
+
+        expect(result).toBe(false);
+        expect(showMessage).not.toHaveBeenCalled();
+      });
+    });
+
+    // --- Real-world backward compatibility scenarios ---
+
+    describe('backward compatibility with analytics.page() variants', () => {
+      it('matches when page was called with a name: analytics.page("Dashboard")', async () => {
+        // Customer set rule: equals "Dashboard"
+        // SDK was called: analytics.page('Dashboard') → setCurrentRoute('Dashboard')
+        withRouteRule('^(Dashboard)$');
+        navigateTo('/app/main');
+        (Gist as unknown as Record<string, unknown>).currentRoute = 'Dashboard';
+
+        await handleMessage(message);
+
+        expect(showMessage).toHaveBeenCalledWith(message);
+      });
+
+      it('matches when page was called with no args: analytics.page()', async () => {
+        // Customer set rule: contains "/dashboard"
+        // SDK was called: analytics.page() → setCurrentRoute(window.location.pathname)
+        withRouteRule('^(.*\\/dashboard.*)$');
+        navigateTo('/dashboard');
+        (Gist as unknown as Record<string, unknown>).currentRoute = '/dashboard';
+
+        await handleMessage(message);
+
+        // pathname matches directly; currentRoute = pathname so fallback is skipped
+        expect(showMessage).toHaveBeenCalledWith(message);
+      });
+
+      it('matches pathname even when page was never called', async () => {
+        // Customer set rule: contains "/dashboard"
+        // analytics.page() was never called, so currentRoute = null
+        withRouteRule('^(.*\\/dashboard.*)$');
+        navigateTo('/dashboard');
+        (Gist as unknown as Record<string, unknown>).currentRoute = null;
+
+        await handleMessage(message);
+
+        expect(showMessage).toHaveBeenCalledWith(message);
+      });
+
+      it('matches when currentRoute is a full URL from older SDK behavior', async () => {
+        // Older SDK versions could set currentRoute to the full URL
+        withRouteRule('^(.*\\/dashboard.*)$');
+        navigateTo('/dashboard');
+        (Gist as unknown as Record<string, unknown>).currentRoute = 'http://example.com/dashboard';
+
+        await handleMessage(message);
+
+        // pathname /dashboard matches directly
+        expect(showMessage).toHaveBeenCalledWith(message);
+      });
+
+      it('falls back to full URL currentRoute when pathname does not match legacy name rule', async () => {
+        // Customer set rule: contains "example.com" (legacy - matched against full URL)
+        withRouteRule('^(.*example\\.com.*)$');
+        navigateTo('/dashboard');
+        (Gist as unknown as Record<string, unknown>).currentRoute = 'http://example.com/dashboard';
+
+        await handleMessage(message);
+
+        // pathname /dashboard does NOT match .*example\.com.*
+        // but currentRoute http://example.com/dashboard DOES match
+        expect(showMessage).toHaveBeenCalledWith(message);
+      });
+
+      it('matches full URL exact rule via currentRoute when analytics.page() called without name', async () => {
+        // Customer set rule: equals "https://myapp.com/pricing"
+        // analytics.page() called without a name → currentRoute = full URL
+        withRouteRule('^(https:\\/\\/myapp\\.com\\/pricing)$');
+        navigateTo('/pricing');
+        (Gist as unknown as Record<string, unknown>).currentRoute = 'https://myapp.com/pricing';
+
+        await handleMessage(message);
+
+        // pathname /pricing does NOT match the full URL regex
+        // currentRoute https://myapp.com/pricing DOES match
+        expect(showMessage).toHaveBeenCalledWith(message);
+      });
+
+      it('does not match full URL exact rule when currentRoute is a pathname', async () => {
+        // Same full URL rule, but analytics.page('Pricing') was called with a name
+        // so currentRoute = "Pricing", not the full URL
+        withRouteRule('^(https:\\/\\/myapp\\.com\\/pricing)$');
+        navigateTo('/pricing');
+        (Gist as unknown as Record<string, unknown>).currentRoute = 'Pricing';
+
+        const result = await handleMessage(message);
+
+        // Neither pathname /pricing nor currentRoute "Pricing" matches the full URL regex
+        expect(result).toBe(false);
+        expect(showMessage).not.toHaveBeenCalled();
+      });
+    });
+
+    // --- Edge cases ---
+
+    describe('edge cases', () => {
+      it('handles regex with special characters in path', async () => {
+        withRouteRule('^(.*\\/api\\/v2\\.0\\/users.*)$');
+        navigateTo('/api/v2.0/users');
+
+        await handleMessage(message);
+
+        expect(showMessage).toHaveBeenCalledWith(message);
+      });
+
+      it('handles rule matching path with query params stripped by URL parsing', async () => {
+        // URL parsing extracts only pathname, query params are stripped
+        withRouteRule('^(\\/search)$');
+        navigateTo('/search?q=test');
+
+        await handleMessage(message);
+
+        // pathname is /search (query params stripped by new URL().pathname)
+        expect(showMessage).toHaveBeenCalledWith(message);
+      });
+
+      it('handles rule matching path with hash stripped by URL parsing', async () => {
+        withRouteRule('^(\\/docs)$');
+        navigateTo('/docs#section-1');
+
+        await handleMessage(message);
+
+        // pathname is /docs (hash stripped by new URL().pathname)
+        expect(showMessage).toHaveBeenCalledWith(message);
+      });
+
+      it('handles case-sensitive matching', async () => {
+        withRouteRule('^(\\/Dashboard)$');
+        navigateTo('/dashboard');
+
+        const result = await handleMessage(message);
+
+        // Regex is case-sensitive by default
+        expect(result).toBe(false);
+        expect(showMessage).not.toHaveBeenCalled();
+      });
+
+      it('handles empty route rule string as matching everything', async () => {
+        // Empty regex matches everything
+        withRouteRule('');
+        navigateTo('/anything');
+
+        await handleMessage(message);
+
+        expect(showMessage).toHaveBeenCalledWith(message);
+      });
+
+      it('handles catch-all rule', async () => {
+        withRouteRule('^(.*)$');
+        navigateTo('/literally/any/path');
+
+        await handleMessage(message);
+
+        expect(showMessage).toHaveBeenCalledWith(message);
+      });
+    });
+  });
 });

--- a/src/managers/queue-manager.ts
+++ b/src/managers/queue-manager.ts
@@ -91,15 +91,27 @@ export async function checkCurrentMessagesAfterRouteChange(): Promise<void> {
 export async function handleMessage(message: GistMessage): Promise<boolean> {
   let messageProperties = resolveMessageProperties(message);
   if (messageProperties.hasRouteRule) {
-    let currentUrl = Gist.currentRoute;
-    if (currentUrl == null) {
-      currentUrl = new URL(window.location.href).pathname;
-    }
-    const routeRule = messageProperties.routeRule;
-    log(`Verifying route ${currentUrl} against rule: ${routeRule}`);
-    const urlTester = new RegExp(routeRule);
-    if (!urlTester.test(currentUrl)) {
-      log(`Route ${currentUrl} does not match rule.`);
+    const routeRule = new RegExp(messageProperties.routeRule);
+    const pathname = new URL(window.location.href).pathname;
+
+    // Route rule evaluation checks two values.
+    //
+    // Gist.currentRoute (primary): Set by the SDK's analytics.page() call. This is
+    // what customers have historically built their rules against. The value varies
+    // by call style — analytics.page("Name") sets an arbitrary string like "Name",
+    // analytics.page() sets the full URL, and never calling it leaves currentRoute
+    // null. Existing customers have live rules that depend on all of these formats.
+    //
+    // pathname (fallback): The URL path from window.location. Always available and
+    // always a path like "/dashboard", regardless of how analytics.page() was called.
+    // Catches cases where currentRoute is null or set to a value that doesn't match.
+    const matchesCurrentRoute = Gist.currentRoute != null && routeRule.test(Gist.currentRoute);
+    const matchesPathname = Gist.currentRoute !== pathname && routeRule.test(pathname);
+
+    if (!matchesCurrentRoute && !matchesPathname) {
+      log(
+        `Route ${pathname} (currentRoute: ${Gist.currentRoute}) does not match rule: ${messageProperties.routeRule}`
+      );
       return false;
     }
   }


### PR DESCRIPTION
### Summary

- Route rule matching now checks `Gist.currentRoute` first (primary, backward compatible) then falls back to `window.location.pathname` for cases where `currentRoute` is null or set to a value that doesn't match
- Fixes unreliable page rule behavior caused by `currentRoute` varying depending on how `analytics.page()` is called — with a name (`"Dashboard"`), without args (full URL), or never called (`null`)
- Adds 32 tests covering contains/equals rules, OR logic, exclude rules, DO_NOT_DISPLAY_REGEX, currentRoute fallback, backward compatibility with all `analytics.page()` variants, and edge cases

### Context

`Gist.currentRoute` is set by the SDK's `analytics.page()` call, but its value varies by call style:

| Call style | `currentRoute` value |
|---|---|
| `analytics.page("Dashboard")` | `"Dashboard"` |
| `analytics.page()` | full URL |
| never called | `null` |

The old code only checked `currentRoute` (falling back to pathname only when null), which meant rules could silently fail depending on how the customer integrated the SDK. The new dual-check preserves all existing rule formats while adding `pathname` as a reliable fallback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes message display gating logic based on route rules, which could alter when in-app messages appear or are suppressed across customers’ existing regex rules. Risk is mitigated by extensive new tests covering legacy `analytics.page()` behaviors and edge cases.
> 
> **Overview**
> Fixes route-rule evaluation in `handleMessage` to test both `Gist.currentRoute` and `window.location.pathname`, so rules still match when `currentRoute` is `null`, a legacy full URL, or a named page string.
> 
> Adds a comprehensive `handleMessage` route-rule test suite covering contains/equals patterns, OR/exclude regexes, `DO_NOT_DISPLAY_IN_APP`, root/nested paths, `currentRoute` fallback behavior, and query/hash stripping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1b5ad5ef2f8bd5f6e5e6dbaa83f37bfac69c2f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->