### PR TITLE
Queue call in progress guard check moved above the try block

### DIFF
--- a/src/services/queue-service.ts
+++ b/src/services/queue-service.ts
@@ -24,21 +24,21 @@ export const userQueueNextPullCheckLocalStoreName = 'gist.web.userQueueNextPullC
 export const sessionIdLocalStoreName = 'gist.web.sessionId';
 
 export async function getUserQueue(): Promise<NetworkResponse | undefined> {
+  if (checkInProgress) return;
+  checkInProgress = true;
+
   const existingUserToken = getUserToken();
   let response: NetworkResponse | undefined;
   try {
-    if (!checkInProgress) {
-      checkInProgress = true;
-      const headers: Record<string, string> = {
-        'X-Gist-User-Anonymous': String(isUsingGuestUserToken()),
-        'Content-Language': String(getUserLocale()),
-      };
-      response = await UserNetworkInstance().post(
-        `/api/v4/users?sessionId=${getSessionId()}`,
-        {},
-        { headers }
-      );
-    }
+    const headers: Record<string, string> = {
+      'X-Gist-User-Anonymous': String(isUsingGuestUserToken()),
+      'Content-Language': String(getUserLocale()),
+    };
+    response = await UserNetworkInstance().post(
+      `/api/v4/users?sessionId=${getSessionId()}`,
+      {},
+      { headers }
+    );
   } catch (error) {
     const errorResponse = getNetworkErrorResponse(error);
     if (errorResponse) {


### PR DESCRIPTION
Fixed a bug in getUserQueue() where a concurrent call that got skipped by the checkInProgress guard would still run side effects: actively disabling the SSE flag, writing a stale polling timer to localStorage, and prematurely resetting the guard. Moved the guard above the try block so skipped calls return immediately with no side effects.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small control-flow change that only affects concurrent `getUserQueue()` invocations by returning early before entering the try/finally; primary risk is subtle behavior changes if callers relied on prior side effects during overlap.
> 
> **Overview**
> Prevents overlapping `getUserQueue()` executions by moving the `checkInProgress` guard to the very start of the function and immediately returning `undefined` when a request is already running.
> 
> This ensures only one `/api/v4/users` POST is in-flight at a time, while keeping `checkInProgress` reset via the existing `finally` for the active request.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit add687050ab3eb0d5dd183e2bc70178d64ab9668. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->