### PR TITLE
Added exponential backoff to polling interval if the header is missing or call fails

### DIFF
--- a/src/services/queue-service.ts
+++ b/src/services/queue-service.ts
@@ -80,11 +80,14 @@ function getSessionId(): string {
 }
 
 function scheduleNextQueuePull(response?: NetworkResponse): void {
-  if (response?.headers) {
-    const pollingInterval = response.headers['x-gist-queue-polling-interval'];
-    if (pollingInterval && Number(pollingInterval) > 0) {
-      currentPollingDelayInSeconds = Number(pollingInterval);
-    }
+  const pollingInterval = response?.headers?.['x-gist-queue-polling-interval'];
+  if (pollingInterval && Number(pollingInterval) > 0) {
+    currentPollingDelayInSeconds = Number(pollingInterval);
+  } else {
+    currentPollingDelayInSeconds = Math.min(
+      currentPollingDelayInSeconds * 2,
+      defaultPollingDelayInSeconds
+    );
   }
   const expiryDate = new Date(new Date().getTime() + currentPollingDelayInSeconds * msPerSecond);
   setKeyToLocalStore(

--- a/src/services/queue-service.ts
+++ b/src/services/queue-service.ts
@@ -24,21 +24,21 @@ export const userQueueNextPullCheckLocalStoreName = 'gist.web.userQueueNextPullC
 export const sessionIdLocalStoreName = 'gist.web.sessionId';
 
 export async function getUserQueue(): Promise<NetworkResponse | undefined> {
+  if (checkInProgress) return;
+  checkInProgress = true;
+
   const existingUserToken = getUserToken();
   let response: NetworkResponse | undefined;
   try {
-    if (!checkInProgress) {
-      checkInProgress = true;
-      const headers: Record<string, string> = {
-        'X-Gist-User-Anonymous': String(isUsingGuestUserToken()),
-        'Content-Language': String(getUserLocale()),
-      };
-      response = await UserNetworkInstance().post(
-        `/api/v4/users?sessionId=${getSessionId()}`,
-        {},
-        { headers }
-      );
-    }
+    const headers: Record<string, string> = {
+      'X-Gist-User-Anonymous': String(isUsingGuestUserToken()),
+      'Content-Language': String(getUserLocale()),
+    };
+    response = await UserNetworkInstance().post(
+      `/api/v4/users?sessionId=${getSessionId()}`,
+      {},
+      { headers }
+    );
   } catch (error) {
     const errorResponse = getNetworkErrorResponse(error);
     if (errorResponse) {


### PR DESCRIPTION
On failure the interval doubles each time (10→20→40→...→600s), and the server reasserts control on the next successful response.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk logic change limited to client-side queue polling cadence, but could impact request frequency and perceived latency if the header is absent or responses fail.
> 
> **Overview**
> Implements exponential backoff in `scheduleNextQueuePull` by doubling the next poll delay when `x-gist-queue-polling-interval` is missing/invalid, capped at `defaultPollingDelayInSeconds`.
> 
> Also simplifies the header access logic by using optional chaining and treating successful responses with a valid header as authoritative (resetting the delay to the server-provided value).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3f3874466167391f632e16e5ffc9d65ec5107ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->