### PR TITLE
Defer route-rule evaluation during page load to prevent race condition

### DIFF
--- a/src/gist.test.ts
+++ b/src/gist.test.ts
@@ -230,6 +230,45 @@ describe('Gist', () => {
       await Gist.setup(baseConfig());
       expect(Gist.isDocumentVisible).toBe(true);
     });
+
+    describe('DOMContentLoaded queue recheck', () => {
+      function simulateReadyState(state: string) {
+        Object.defineProperty(document, 'readyState', {
+          value: state,
+          writable: true,
+          configurable: true,
+        });
+      }
+
+      afterEach(() => {
+        simulateReadyState('complete');
+      });
+
+      it('registers listener when page is loading', async () => {
+        simulateReadyState('loading');
+        const addSpy = vi.spyOn(document, 'addEventListener');
+
+        await Gist.setup(baseConfig());
+
+        expect(addSpy).toHaveBeenCalledWith('DOMContentLoaded', expect.any(Function), {
+          once: true,
+        });
+        addSpy.mockRestore();
+      });
+
+      it('skips listener when page is not loading', async () => {
+        simulateReadyState('complete');
+        const addSpy = vi.spyOn(document, 'addEventListener');
+
+        await Gist.setup(baseConfig());
+
+        const domContentLoadedCalls = addSpy.mock.calls.filter(
+          ([event]) => event === 'DOMContentLoaded'
+        );
+        expect(domContentLoadedCalls).toHaveLength(0);
+        addSpy.mockRestore();
+      });
+    });
   });
 
   describe('setCurrentRoute', () => {

--- a/src/gist.test.ts
+++ b/src/gist.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { GistConfig, GistMessage, DisplaySettings } from './types';
 import type { InboxMessage } from './managers/inbox-message-manager';
 

--- a/src/gist.ts
+++ b/src/gist.ts
@@ -79,6 +79,10 @@ export default class Gist {
 
     await startQueueListener();
 
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', () => void checkMessageQueue(), { once: true });
+    }
+
     document.addEventListener(
       'visibilitychange',
       async () => {

--- a/src/managers/queue-manager.test.ts
+++ b/src/managers/queue-manager.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   checkMessageQueue,
   stopSSEListener,

--- a/src/managers/queue-manager.test.ts
+++ b/src/managers/queue-manager.test.ts
@@ -602,7 +602,7 @@ describe('queue-manager', () => {
 
         await handleMessage(message);
 
-        // pathname /dashboard matches directly
+        // currentRoute http://example.com/dashboard matches .*\/dashboard.*
         expect(showMessage).toHaveBeenCalledWith(message);
       });
 
@@ -708,6 +708,83 @@ describe('queue-manager', () => {
 
         await handleMessage(message);
 
+        expect(showMessage).toHaveBeenCalledWith(message);
+      });
+    });
+
+    // --- Race condition: page still loading ---
+
+    describe('defers messages while page is loading', () => {
+      function simulateReadyState(state: string) {
+        Object.defineProperty(document, 'readyState', {
+          value: state,
+          writable: true,
+          configurable: true,
+        });
+      }
+
+      beforeEach(() => {
+        (Gist as unknown as Record<string, unknown>).currentRoute = null;
+      });
+
+      afterEach(() => {
+        simulateReadyState('complete');
+      });
+
+      it('defers message with route rule when page is loading and route is not set', async () => {
+        simulateReadyState('loading');
+        withRouteRule('^(.*\\/dashboard.*)$');
+        navigateTo('/dashboard');
+
+        const result = await handleMessage(message);
+
+        expect(result).toBe(false);
+        expect(showMessage).not.toHaveBeenCalled();
+      });
+
+      it('evaluates immediately when currentRoute is set even during loading', async () => {
+        simulateReadyState('loading');
+        withRouteRule('^(.*\\/dashboard.*)$');
+        navigateTo('/dashboard');
+        (Gist as unknown as Record<string, unknown>).currentRoute = '/dashboard';
+
+        await handleMessage(message);
+
+        expect(showMessage).toHaveBeenCalledWith(message);
+      });
+
+      it('evaluates once DOM is interactive even if currentRoute is null', async () => {
+        simulateReadyState('interactive');
+        withRouteRule('^(.*\\/dashboard.*)$');
+        navigateTo('/dashboard');
+
+        await handleMessage(message);
+
+        expect(showMessage).toHaveBeenCalledWith(message);
+      });
+
+      it('defers exclusion rule evaluation when page is loading', async () => {
+        simulateReadyState('loading');
+        const origin = window.location.origin;
+        const escaped = origin.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        withRouteRule(`^(?!.*(?:(^${escaped}\\/dashboard\\/$))).*$`);
+        navigateTo('/dashboard/');
+
+        const result = await handleMessage(message);
+
+        expect(result).toBe(false);
+        expect(showMessage).not.toHaveBeenCalled();
+      });
+
+      it('shows message without route rule even when page is loading', async () => {
+        simulateReadyState('loading');
+        vi.mocked(resolveMessageProperties).mockReturnValue(defaultProperties);
+        navigateTo('/dashboard');
+
+        const result = await handleMessage(message);
+
+        // Not deferred (no route rule), but showMessage mock returns null
+        expect(result).toBe(false);
         expect(showMessage).toHaveBeenCalledWith(message);
       });
     });

--- a/src/managers/queue-manager.ts
+++ b/src/managers/queue-manager.ts
@@ -91,6 +91,11 @@ export async function checkCurrentMessagesAfterRouteChange(): Promise<void> {
 export async function handleMessage(message: GistMessage): Promise<boolean> {
   let messageProperties = resolveMessageProperties(message);
   if (messageProperties.hasRouteRule) {
+    if (Gist.currentRoute == null && document.readyState === 'loading') {
+      log(`Deferring message ${message.queueId}, page not fully loaded`);
+      return false;
+    }
+
     const routeRule = new RegExp(messageProperties.routeRule);
     const pathname = new URL(window.location.href).pathname;
 


### PR DESCRIPTION
Addresses: [INAPP-14183](https://linear.app/customerio/issue/INAPP-14183/ladybird-srl-trouble-with-in-app-exclusion-page-rules)

Messages with page rules (including exclusion rules) were being evaluated before `analytics.page()` had a chance to set `currentRoute`. With `currentRoute` still null, the pathname fallback could incorrectly match against exclusion rules, causing messages to show on pages they should have been excluded from.

This defers route-rule evaluation while `document.readyState === 'loading'` and re-checks the queue on `DOMContentLoaded`, by which point deferred scripts (including the analytics call) have executed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes message eligibility logic during initial page load by deferring route-rule evaluation and adding a DOMContentLoaded-triggered recheck; could impact when/if in-app messages appear on first render.
> 
> **Overview**
> Prevents a page-load race where messages with route rules (including exclusion rules) could be evaluated before `Gist.currentRoute` is set, leading to incorrect matches.
> 
> `handleMessage` now **defers** route-rule evaluation when `document.readyState === 'loading'` and `currentRoute` is still null, and `Gist.setup` schedules a one-time `DOMContentLoaded` queue recheck to process any deferred messages.
> 
> Updates unit tests in `gist.test.ts` and `queue-manager.test.ts` to cover the new DOM-ready deferral and recheck behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd78f1bb4d1973fd3eef07258035681e09dd0c0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->