### PR TITLE
feat: debug widget

### DIFF
--- a/src/gist.ts
+++ b/src/gist.ts
@@ -104,6 +104,7 @@ export default class Gist {
     log(`Current route set to: ${route}`);
     await checkCurrentMessagesAfterRouteChange();
     await checkMessageQueue();
+    this.events?.dispatch('routeChanged', route);
   }
 
   static async setUserToken(userToken: string, expiryDate?: Date): Promise<void> {

--- a/src/gist.ts
+++ b/src/gist.ts
@@ -27,6 +27,7 @@ import {
   removeCustomAttribute,
 } from './managers/custom-attribute-manager';
 import { setupPreview } from './utilities/preview-mode';
+import { setupDebugOverlay } from './utilities/debug-mode';
 import {
   getInboxMessagesFromLocalStore,
   updateInboxMessageOpenState,
@@ -65,6 +66,7 @@ export default class Gist {
     this.currentRoute = null;
     this.isDocumentVisible = true;
     this.config.isPreviewSession = setupPreview();
+    setupDebugOverlay();
     clearExpiredFromLocalStore();
 
     log(`Setup complete on ${this.config.env} environment.`);
@@ -91,6 +93,10 @@ export default class Gist {
       },
       false
     );
+  }
+
+  static setupDebugOverlay(): void {
+    setupDebugOverlay();
   }
 
   static async setCurrentRoute(route: string): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { setupDebugOverlay } from './utilities/debug-mode';
-if (typeof window !== 'undefined') setupDebugOverlay(); // fallback for when initialization fails
+if (typeof window !== 'undefined') setupDebugOverlay();
 
 export { default } from './gist';
 export type { GistConfig, GistEnv, GistMessage, DisplaySettings, MessageProperties } from './types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,5 @@
+import { setupDebugOverlay } from './utilities/debug-mode';
+if (typeof window !== 'undefined') setupDebugOverlay(); // fallback for when initialization fails
+
 export { default } from './gist';
 export type { GistConfig, GistEnv, GistMessage, DisplaySettings, MessageProperties } from './types';

--- a/src/managers/debug-overlay-manager.ts
+++ b/src/managers/debug-overlay-manager.ts
@@ -6,15 +6,27 @@ import { getMessagesFromLocalStore } from './message-user-queue-manager';
 import { getEligibleBroadcasts } from './message-broadcast-manager';
 import { getUserToken, isUsingGuestUserToken } from './user-manager';
 import { settings } from '../services/settings';
+import { getPollingIntervalSeconds } from '../services/queue-service';
 import { mapElementIdToOverlayPosition, getCurrentDisplayType } from '../utilities/message-utils';
 
 import type { GistMessage } from '../types';
 
-const OVERLAY_ID = 'gist-debug-overlay';
 const STYLE_ID = 'gist-debug-overlay-styles';
 const SETUP_POLL_MS = 2000;
-const FALLBACK_POLL_MS = 10000;
+const FALLBACK_POLL_MS = 5000;
 
+interface OverlayRefs {
+  root: HTMLElement;
+  configRows: HTMLElement;
+  configDetail: HTMLElement;
+  userValue: HTMLElement;
+  routeValue: HTMLElement;
+  routeDetail: HTMLElement;
+  messagesLabel: HTMLElement;
+  messagesList: HTMLElement;
+}
+
+let refs: OverlayRefs | null = null;
 let eventsSubscribed = false;
 let refreshing = false;
 let pollIntervalId: ReturnType<typeof setInterval> | null = null;
@@ -30,26 +42,23 @@ function getDebugDisplayType(msg: GistMessage): ReturnType<typeof getCurrentDisp
   });
 }
 
-function formatOverlayPositionLabel(overlayPosition: string): string {
-  return overlayPosition.replace(/([A-Z])/g, ' $1').toLowerCase();
-}
-
 function msgProps(msg: GistMessage): Array<[string, string]> {
   const gist = msg.properties?.gist;
   const pairs: Array<[string, string]> = [];
-  if (gist?.routeRuleWeb) pairs.push(['route rule', String(gist.routeRuleWeb)]);
+  if (gist?.routeRuleWeb) pairs.push(['Route Rule', String(gist.routeRuleWeb)]);
   const elementId = gist?.elementId ?? msg.elementId;
   const displayType = getDebugDisplayType(msg);
   if (elementId && displayType === 'overlay') {
     const overlayPosition = mapElementIdToOverlayPosition(String(elementId));
-    if (overlayPosition) pairs.push(['position', formatOverlayPositionLabel(overlayPosition)]);
+    if (overlayPosition)
+      pairs.push(['Position', overlayPosition.replace(/([A-Z])/g, ' $1').toLowerCase()]);
   } else if (elementId && displayType !== 'modal') {
-    pairs.push(['target', String(elementId)]);
+    pairs.push(['Target', String(elementId)]);
   }
   const position = gist?.position ?? msg.position;
-  if (position && displayType !== 'overlay') pairs.push(['position', String(position)]);
+  if (position && displayType !== 'overlay') pairs.push(['Position', String(position)]);
   const tooltip = gist?.tooltipPosition ?? msg.tooltipPosition;
-  if (tooltip) pairs.push(['tooltip', String(tooltip)]);
+  if (tooltip) pairs.push(['Tooltip', String(tooltip)]);
   return pairs;
 }
 
@@ -63,6 +72,22 @@ function routeRuleMismatches(rule: string): boolean {
   } catch {
     return true;
   }
+}
+
+function buildKvRow(key: string, value: string, error = false): HTMLElement {
+  const row = el('div', { className: 'gist-debug-msg-row' });
+  row.appendChild(el('span', { className: 'gist-debug-msg-key', textContent: key }));
+  row.appendChild(
+    el('span', {
+      className: error ? 'gist-debug-msg-val gist-debug-val-error' : 'gist-debug-msg-val',
+      textContent: value,
+    })
+  );
+  return row;
+}
+
+function renderKv(container: HTMLElement, pairs: Array<[string, string]>, error = false): void {
+  container.replaceChildren(...pairs.map(([key, value]) => buildKvRow(key, value, error)));
 }
 
 function buildMessageEl(msg: GistMessage, state: 'active' | 'queued'): HTMLElement {
@@ -96,7 +121,7 @@ function buildMessageEl(msg: GistMessage, state: 'active' | 'queued'): HTMLEleme
     let statusClass: string | null = null;
     let statusText: string | null = null;
 
-    if (key === 'route rule') {
+    if (key === 'Route Rule') {
       const mismatch = routeRuleMismatches(value);
       statusClass = mismatch ? 'gist-debug-route-mismatch' : 'gist-debug-element-found';
       statusText = mismatch ? '✕' : '✓';
@@ -104,7 +129,7 @@ function buildMessageEl(msg: GistMessage, state: 'active' | 'queued'): HTMLEleme
         inlineDetails.push(
           'Route rule does not match current route. If it should, verify the route is set correctly and that analytics.page() is called on route changes.'
         );
-    } else if (key === 'target') {
+    } else if (key === 'Target') {
       const exists = !!findElement(value);
       statusClass = exists ? 'gist-debug-element-found' : 'gist-debug-route-mismatch';
       statusText = exists ? '✓' : '✕';
@@ -131,33 +156,16 @@ function buildMessageEl(msg: GistMessage, state: 'active' | 'queued'): HTMLEleme
   return item;
 }
 
-function buildExpandDetail(items: Array<string | Node[]>): HTMLElement {
+function buildDetailPanel(text: string): HTMLElement {
   const detail = el('div', { className: 'gist-debug-expand-detail' });
   const list = el('ul', { className: 'gist-debug-expand-list' });
-  for (const item of items) {
-    const li = el('li', {});
-    if (typeof item === 'string') {
-      li.textContent = item;
-    } else {
-      for (const node of item)
-        li.appendChild(node instanceof Node ? node : document.createTextNode(String(node)));
-    }
-    list.appendChild(li);
-  }
+  list.appendChild(el('li', { textContent: text }));
   detail.appendChild(list);
   return detail;
 }
 
-function buildSection(labelId?: string, valueId?: string, listId?: string): HTMLElement {
-  const section = el('div', { className: 'gist-debug-section' });
-  if (labelId) section.appendChild(el('div', { className: 'gist-debug-label', id: labelId }));
-  if (valueId) section.appendChild(el('div', { className: 'gist-debug-value', id: valueId }));
-  if (listId) section.appendChild(el('div', { id: listId }));
-  return section;
-}
-
-function buildOverlay(): HTMLElement {
-  const overlay = el('div', { id: OVERLAY_ID });
+function buildOverlay(): OverlayRefs {
+  const root = el('div', { id: 'gist-debug-overlay' });
 
   const header = el('div', { className: 'gist-debug-header' });
   header.appendChild(
@@ -171,132 +179,108 @@ function buildOverlay(): HTMLElement {
     ariaLabel: 'Dismiss debug overlay',
     textContent: '×',
   });
-  closeBtn.addEventListener('click', () => {
-    overlay.remove();
-    document.getElementById(STYLE_ID)?.remove();
-    if (pollIntervalId !== null) {
-      clearInterval(pollIntervalId);
-      pollIntervalId = null;
-    }
-    unsubscribeEvents();
-  });
+  closeBtn.addEventListener('click', teardown);
   header.appendChild(closeBtn);
-  overlay.appendChild(header);
+  root.appendChild(header);
 
-  // Config section
+  // Config
   const configSection = el('div', { className: 'gist-debug-section' });
   const configLabel = el('div', { className: 'gist-debug-label' });
   configLabel.appendChild(el('span', { textContent: 'Config' }));
   configSection.appendChild(configLabel);
-  configSection.appendChild(el('div', { id: 'gist-debug-config-rows' }));
-  const configDetail = buildExpandDetail([
-    "Ensure you're using the correct credentials in the SDK initialization snippet",
-    'Ensure your credentials are active in Journeys',
-  ]);
+  const configRows = el('div', {});
+  configSection.appendChild(configRows);
+  const configDetail = buildDetailPanel('Verify your site ID and credentials are correct.');
   configSection.appendChild(configDetail);
-  overlay.appendChild(configSection);
+  root.appendChild(configSection);
 
-  // User section
-  overlay.appendChild(buildSection('gist-debug-user-label', 'gist-debug-user-value'));
+  // User
+  const userSection = el('div', { className: 'gist-debug-section' });
+  const userLabel = el('div', { className: 'gist-debug-label', textContent: 'User' });
+  userSection.appendChild(userLabel);
+  const userValue = el('div', { className: 'gist-debug-value' });
+  userSection.appendChild(userValue);
+  root.appendChild(userSection);
 
-  // Route section
+  // Route
   const routeSection = el('div', { className: 'gist-debug-section' });
   const routeLabel = el('div', { className: 'gist-debug-label' });
   routeLabel.appendChild(el('span', { textContent: 'Route' }));
   routeSection.appendChild(routeLabel);
-  routeSection.appendChild(
-    el('div', { className: 'gist-debug-value', id: 'gist-debug-route-value' })
+  const routeValue = el('div', { className: 'gist-debug-value' });
+  routeSection.appendChild(routeValue);
+  const routeDetail = buildDetailPanel(
+    'The current route is used to match against potential message page rules.'
   );
-  const inlineCode = el('code', {
-    className: 'gist-debug-inline-code',
-    textContent: 'analytics.page()',
-  });
-  const routeDetail = buildExpandDetail([
-    'The current route is used to match against message page rules if set.',
-    [
-      document.createTextNode('For single-page applications, ensure '),
-      inlineCode,
-      document.createTextNode(' is called on every route change'),
-    ],
-  ]);
   routeSection.appendChild(routeDetail);
-  overlay.appendChild(routeSection);
+  root.appendChild(routeSection);
 
-  overlay.appendChild(
-    buildSection('gist-debug-messages-label', undefined, 'gist-debug-messages-list')
-  );
-  return overlay;
+  // Messages
+  const messagesSection = el('div', { className: 'gist-debug-section' });
+  const messagesLabel = el('div', { className: 'gist-debug-label' });
+  messagesSection.appendChild(messagesLabel);
+  const messagesList = el('div', {});
+  messagesSection.appendChild(messagesList);
+  root.appendChild(messagesSection);
+
+  return {
+    root,
+    configRows,
+    configDetail,
+    userValue,
+    routeValue,
+    routeDetail,
+    messagesLabel,
+    messagesList,
+  };
 }
 
-function buildKvRow(key: string, value: string, error = false): HTMLElement {
-  const row = el('div', { className: 'gist-debug-msg-row' });
-  row.appendChild(el('span', { className: 'gist-debug-msg-key', textContent: key }));
-  row.appendChild(
-    el('span', {
-      className: error ? 'gist-debug-msg-val gist-debug-val-error' : 'gist-debug-msg-val',
-      textContent: value,
-    })
-  );
-  return row;
-}
-
-function renderKv(container: HTMLElement, pairs: Array<[string, string]>, error = false): void {
-  container.innerHTML = '';
-  for (const [key, value] of pairs) container.appendChild(buildKvRow(key, value, error));
+function teardown(): void {
+  if (!refs) return;
+  refs.root.remove();
+  document.getElementById(STYLE_ID)?.remove();
+  if (pollIntervalId !== null) {
+    clearInterval(pollIntervalId);
+    pollIntervalId = null;
+  }
+  unsubscribeEvents();
+  refs = null;
 }
 
 function refreshSync(): void {
-  if (!document.getElementById(OVERLAY_ID)) return;
+  if (!refs) return;
 
-  // Config + init status
-  const configRows = document.getElementById('gist-debug-config-rows');
-  if (configRows) {
-    if (!Gist.config) {
-      renderKv(configRows, [['Status', 'NOT INITIALIZED']], true);
-    } else {
-      renderKv(configRows, [
-        ['Status', 'INITIALIZED'],
-        ['Connection', settings.useSSE() ? 'SSE' : 'polling'],
-        ['Site ID', `${Gist.config.siteId.slice(0, 3)}…`],
-      ]);
-    }
+  if (!Gist.config) {
+    renderKv(refs.configRows, [['Status', 'NOT INITIALIZED']], true);
+  } else {
+    renderKv(refs.configRows, [
+      ['Site ID', Gist.config.siteId],
+      ['Connection', settings.useSSE() ? 'SSE' : `Polling ${getPollingIntervalSeconds()}s`],
+    ]);
+  }
+  refs.configDetail.style.display = Gist.config ? 'none' : '';
+
+  const token = getUserToken();
+  if (!token) {
+    refs.userValue.textContent = '(none)';
+  } else if (isUsingGuestUserToken()) {
+    refs.userValue.textContent = '(anonymous)';
+  } else {
+    refs.userValue.textContent = token.length > 32 ? `${token.slice(0, 32)}…` : token;
   }
 
-  // User
-  const userLabel = document.getElementById('gist-debug-user-label');
-  const userValue = document.getElementById('gist-debug-user-value');
-  if (userLabel && userValue) {
-    userLabel.textContent = 'User';
-    const token = getUserToken();
-    if (!token) {
-      userValue.textContent = '(none)';
-    } else if (isUsingGuestUserToken()) {
-      userValue.textContent = '(anonymous)';
-    } else {
-      userValue.textContent = token.length > 32 ? `${token.slice(0, 32)}…` : token;
-    }
-  }
-
-  // Route — value only, label and detail are static DOM from buildOverlay
-  const routeValue = document.getElementById('gist-debug-route-value');
-  if (routeValue) {
-    const route = Gist.currentRoute;
-    routeValue.innerHTML = '';
-    routeValue.appendChild(
-      el('span', {
-        className: route ? 'gist-debug-msg-val' : 'gist-debug-msg-val gist-debug-val-error',
-        textContent: route ?? 'NONE',
-      })
-    );
-  }
+  const route = Gist.currentRoute;
+  refs.routeValue.replaceChildren(
+    el('span', {
+      className: route ? 'gist-debug-msg-val' : 'gist-debug-msg-val gist-debug-val-error',
+      textContent: route ?? 'NONE',
+    })
+  );
+  refs.routeDetail.style.display = route ? 'none' : '';
 }
 
 async function refreshMessages(): Promise<void> {
-  if (refreshing) return;
-  if (!document.getElementById(OVERLAY_ID)) return;
-  const label = document.getElementById('gist-debug-messages-label');
-  const list = document.getElementById('gist-debug-messages-list');
-  if (!label || !list) return;
+  if (refreshing || !refs) return;
 
   refreshing = true;
   try {
@@ -314,10 +298,11 @@ async function refreshMessages(): Promise<void> {
     });
     const total = active.length + queued.length;
 
-    label.textContent = `Messages (${total})`;
-    list.innerHTML = '';
-    for (const msg of active) list.appendChild(buildMessageEl(msg, 'active'));
-    for (const msg of queued) list.appendChild(buildMessageEl(msg, 'queued'));
+    refs.messagesLabel.textContent = `Messages (${total})`;
+    refs.messagesList.replaceChildren(
+      ...active.map((msg) => buildMessageEl(msg, 'active')),
+      ...queued.map((msg) => buildMessageEl(msg, 'queued'))
+    );
   } finally {
     refreshing = false;
   }
@@ -332,20 +317,16 @@ function onInboxUpdated(): void {
   void refreshMessages();
 }
 
-// Lazily subscribe to Gist events and patch setCurrentRoute. Called on each
-// poll tick until Gist.events is available (Gist.setup() may run after load).
 function subscribeEvents(): void {
   if (eventsSubscribed || !Gist.events) return;
   Gist.events.on('messageShown', onMessageChanged);
   Gist.events.on('messageDismissed', onMessageChanged);
   Gist.events.on('messageInboxUpdated', onInboxUpdated);
 
-  // No route-changed event exists — intercept setCurrentRoute instead.
   originalSetCurrentRoute = Gist.setCurrentRoute.bind(Gist);
   Gist.setCurrentRoute = async (route: string) => {
     await originalSetCurrentRoute!(route);
-    refreshSync();
-    void refreshMessages();
+    onMessageChanged();
   };
 
   eventsSubscribed = true;
@@ -380,10 +361,10 @@ function reschedulePoll(intervalMs: number): void {
 }
 
 export function initDebugOverlay(): void {
-  if (pollIntervalId !== null) return;
+  if (refs || pollIntervalId !== null) return;
   injectStylesheet(STYLE_ID, DEBUG_OVERLAY_CSS);
-  const overlay = buildOverlay();
-  appendToBody(overlay);
+  refs = buildOverlay();
+  appendToBody(refs.root);
   reschedulePoll(SETUP_POLL_MS);
   void refreshAll();
 }

--- a/src/managers/debug-overlay-manager.ts
+++ b/src/managers/debug-overlay-manager.ts
@@ -12,9 +12,11 @@ import type { GistMessage } from '../types';
 
 const OVERLAY_ID = 'gist-debug-overlay';
 const STYLE_ID = 'gist-debug-overlay-styles';
-const POLL_INTERVAL_MS = 2000;
+const SETUP_POLL_MS = 2000;
+const FALLBACK_POLL_MS = 10000;
 
 let eventsSubscribed = false;
+let refreshing = false;
 let pollIntervalId: ReturnType<typeof setInterval> | null = null;
 let originalSetCurrentRoute: typeof Gist.setCurrentRoute | null = null;
 
@@ -290,29 +292,35 @@ function refreshSync(): void {
 }
 
 async function refreshMessages(): Promise<void> {
+  if (refreshing) return;
   if (!document.getElementById(OVERLAY_ID)) return;
   const label = document.getElementById('gist-debug-messages-label');
   const list = document.getElementById('gist-debug-messages-list');
   if (!label || !list) return;
 
-  const active = Gist.currentMessages ?? [];
-  const [userMsgs, broadcasts] = Gist.config
-    ? await Promise.all([getMessagesFromLocalStore(), getEligibleBroadcasts()])
-    : [[], []];
-  const activeIds = new Set(active.map((m) => m.queueId ?? m.messageId));
-  const seen = new Set<string>();
-  const queued = [...broadcasts, ...userMsgs].filter((m) => {
-    const id = m.queueId ?? m.messageId;
-    if (activeIds.has(id) || seen.has(id)) return false;
-    seen.add(id);
-    return true;
-  });
-  const total = active.length + queued.length;
+  refreshing = true;
+  try {
+    const active = Gist.currentMessages ?? [];
+    const [userMsgs, broadcasts] = Gist.config
+      ? await Promise.all([getMessagesFromLocalStore(), getEligibleBroadcasts()])
+      : [[], []];
+    const activeIds = new Set(active.map((m) => m.queueId ?? m.messageId));
+    const seen = new Set<string>();
+    const queued = [...broadcasts, ...userMsgs].filter((m) => {
+      const id = m.queueId ?? m.messageId;
+      if (activeIds.has(id) || seen.has(id)) return false;
+      seen.add(id);
+      return true;
+    });
+    const total = active.length + queued.length;
 
-  label.textContent = `Messages (${total})`;
-  list.innerHTML = '';
-  for (const msg of active) list.appendChild(buildMessageEl(msg, 'active'));
-  for (const msg of queued) list.appendChild(buildMessageEl(msg, 'queued'));
+    label.textContent = `Messages (${total})`;
+    list.innerHTML = '';
+    for (const msg of active) list.appendChild(buildMessageEl(msg, 'active'));
+    for (const msg of queued) list.appendChild(buildMessageEl(msg, 'queued'));
+  } finally {
+    refreshing = false;
+  }
 }
 
 function onMessageChanged(): void {
@@ -358,9 +366,17 @@ function unsubscribeEvents(): void {
 }
 
 async function refreshAll(): Promise<void> {
-  subscribeEvents();
+  if (!eventsSubscribed) {
+    subscribeEvents();
+    if (eventsSubscribed) reschedulePoll(FALLBACK_POLL_MS);
+  }
   refreshSync();
   await refreshMessages();
+}
+
+function reschedulePoll(intervalMs: number): void {
+  if (pollIntervalId !== null) clearInterval(pollIntervalId);
+  pollIntervalId = setInterval(() => void refreshAll(), intervalMs);
 }
 
 export function initDebugOverlay(): void {
@@ -368,6 +384,6 @@ export function initDebugOverlay(): void {
   injectStylesheet(STYLE_ID, DEBUG_OVERLAY_CSS);
   const overlay = buildOverlay();
   appendToBody(overlay);
+  reschedulePoll(SETUP_POLL_MS);
   void refreshAll();
-  pollIntervalId = setInterval(() => void refreshAll(), POLL_INTERVAL_MS);
 }

--- a/src/managers/debug-overlay-manager.ts
+++ b/src/managers/debug-overlay-manager.ts
@@ -1,0 +1,350 @@
+import Gist from '../gist';
+import { el, injectStylesheet, appendToBody } from '../utilities/dom';
+import { version as SDK_VERSION } from '../../package.json';
+import { DEBUG_OVERLAY_CSS } from './debug-overlay-styles';
+import { getMessagesFromLocalStore } from './message-user-queue-manager';
+import { getEligibleBroadcasts } from './message-broadcast-manager';
+import { getUserToken, isUsingGuestUserToken } from './user-manager';
+import { positions } from './page-component-manager';
+import { settings } from '../services/settings';
+import { mapElementIdToOverlayPosition } from '../utilities/message-utils';
+
+import type { GistMessage } from '../types';
+
+const OVERLAY_ID = 'gist-debug-overlay';
+const STYLE_ID = 'gist-debug-overlay-styles';
+const POLL_INTERVAL_MS = 2000;
+
+let eventsSubscribed = false;
+let pollIntervalId: ReturnType<typeof setInterval> | null = null;
+
+function getDebugDisplayType(msg: GistMessage): 'modal' | 'overlay' | 'inline' | 'tooltip' {
+  const gist = msg.properties?.gist;
+  const tooltipPos = gist?.tooltipPosition ?? msg.tooltipPosition;
+  if (tooltipPos) return 'tooltip';
+  const elementId = gist?.elementId ?? msg.elementId;
+  if (elementId && positions.includes(String(elementId))) return 'overlay';
+  if (elementId) return 'inline';
+  return 'modal';
+}
+
+function formatOverlayPositionLabel(overlayPosition: string): string {
+  return overlayPosition.replace(/([A-Z])/g, ' $1').toLowerCase();
+}
+
+function msgProps(msg: GistMessage): Array<[string, string]> {
+  const gist = msg.properties?.gist;
+  const pairs: Array<[string, string]> = [];
+  if (gist?.routeRuleWeb) pairs.push(['route rule', String(gist.routeRuleWeb)]);
+  const elementId = gist?.elementId ?? msg.elementId;
+  const displayType = getDebugDisplayType(msg);
+  if (elementId && displayType === 'overlay') {
+    const overlayPosition = mapElementIdToOverlayPosition(String(elementId));
+    if (overlayPosition) pairs.push(['position', formatOverlayPositionLabel(overlayPosition)]);
+  } else if (elementId && displayType !== 'modal') {
+    pairs.push(['target', String(elementId)]);
+  }
+  const position = gist?.position ?? msg.position;
+  if (position && displayType !== 'overlay') pairs.push(['position', String(position)]);
+  const tooltip = gist?.tooltipPosition ?? msg.tooltipPosition;
+  if (tooltip) pairs.push(['tooltip', String(tooltip)]);
+  return pairs;
+}
+
+function routeRuleMismatches(rule: string): boolean {
+  try {
+    const re = new RegExp(rule);
+    const pathname = new URL(window.location.href).pathname;
+    const matchesCurrent = Gist.currentRoute != null && re.test(Gist.currentRoute);
+    const matchesPathname = Gist.currentRoute !== pathname && re.test(pathname);
+    return !matchesCurrent && !matchesPathname;
+  } catch {
+    return false;
+  }
+}
+
+function buildMessageEl(msg: GistMessage, state: 'active' | 'queued'): HTMLElement {
+  const item = el('div', { className: 'gist-debug-msg' });
+  const meta = el('div', { className: 'gist-debug-msg-meta' });
+  meta.appendChild(
+    el('span', { className: 'gist-debug-msg-type', textContent: getDebugDisplayType(msg) })
+  );
+  meta.appendChild(
+    el('span', {
+      className: `gist-debug-msg-state gist-debug-msg-state--${state}`,
+      textContent: state,
+    })
+  );
+  if (msg.instanceId) {
+    const dismiss = el('button', { className: 'gist-debug-msg-dismiss', textContent: '×' });
+    dismiss.addEventListener('click', () => {
+      refreshSync();
+      void Gist.dismissMessage(msg.instanceId!).then(() => {
+        refreshSync();
+        void refreshMessages();
+      });
+    });
+    meta.appendChild(dismiss);
+  }
+  item.appendChild(meta);
+
+  const inlineDetails: string[] = [];
+
+  for (const [key, value] of msgProps(msg)) {
+    let statusClass: string | null = null;
+    let statusText: string | null = null;
+
+    if (key === 'route rule') {
+      const mismatch = routeRuleMismatches(value);
+      statusClass = mismatch ? 'gist-debug-route-mismatch' : 'gist-debug-element-found';
+      statusText = mismatch ? '✕' : '✓';
+      if (mismatch)
+        inlineDetails.push(
+          'Route rule does not match current route. If it should, verify the route is set correctly and that analytics.page() is called on route changes.'
+        );
+    } else if (key === 'target') {
+      const exists = !!(document.getElementById(value) ?? document.querySelector(value));
+      statusClass = exists ? 'gist-debug-element-found' : 'gist-debug-route-mismatch';
+      statusText = exists ? '✓' : '✕';
+      if (!exists)
+        inlineDetails.push(
+          'Target element not found on the page. If it should, verify the selector is correct.'
+        );
+    }
+
+    const row = buildKvRow(key, value);
+    if (statusClass && statusText)
+      row.appendChild(el('span', { className: statusClass, textContent: statusText }));
+    item.appendChild(row);
+  }
+
+  if (inlineDetails.length > 0) {
+    const detailList = el('ul', { className: 'gist-debug-msg-details' });
+    for (const text of inlineDetails) {
+      detailList.appendChild(el('li', { textContent: text }));
+    }
+    item.appendChild(detailList);
+  }
+
+  return item;
+}
+
+function buildExpandDetail(items: Array<string | Node[]>): HTMLElement {
+  const detail = el('div', { className: 'gist-debug-expand-detail' });
+  const list = el('ul', { className: 'gist-debug-expand-list' });
+  for (const item of items) {
+    const li = el('li', {});
+    if (typeof item === 'string') {
+      li.textContent = item;
+    } else {
+      for (const node of item)
+        li.appendChild(node instanceof Node ? node : document.createTextNode(String(node)));
+    }
+    list.appendChild(li);
+  }
+  detail.appendChild(list);
+  return detail;
+}
+
+function buildSection(labelId?: string, valueId?: string, listId?: string): HTMLElement {
+  const section = el('div', { className: 'gist-debug-section' });
+  if (labelId) section.appendChild(el('div', { className: 'gist-debug-label', id: labelId }));
+  if (valueId) section.appendChild(el('div', { className: 'gist-debug-value', id: valueId }));
+  if (listId) section.appendChild(el('div', { id: listId }));
+  return section;
+}
+
+function buildOverlay(): HTMLElement {
+  const overlay = el('div', { id: OVERLAY_ID });
+
+  const header = el('div', { className: 'gist-debug-header' });
+  header.appendChild(
+    el('span', {
+      className: 'gist-debug-title',
+      textContent: `Customer.io In-App SDK ${SDK_VERSION}`,
+    })
+  );
+  const closeBtn = el('button', {
+    id: 'gist-debug-overlay-close',
+    ariaLabel: 'Dismiss debug overlay',
+    textContent: '×',
+  });
+  closeBtn.addEventListener('click', () => {
+    overlay.remove();
+    document.getElementById(STYLE_ID)?.remove();
+    if (pollIntervalId !== null) {
+      clearInterval(pollIntervalId);
+      pollIntervalId = null;
+    }
+  });
+  header.appendChild(closeBtn);
+  overlay.appendChild(header);
+
+  // Config section
+  const configSection = el('div', { className: 'gist-debug-section' });
+  const configLabel = el('div', { className: 'gist-debug-label' });
+  configLabel.appendChild(el('span', { textContent: 'Config' }));
+  configSection.appendChild(configLabel);
+  configSection.appendChild(el('div', { id: 'gist-debug-config-rows' }));
+  const configDetail = buildExpandDetail([
+    "Ensure you're using the correct credentials in the SDK initialization snippet",
+    'Ensure your credentials are active in Journeys',
+  ]);
+  configSection.appendChild(configDetail);
+  overlay.appendChild(configSection);
+
+  // User section
+  overlay.appendChild(buildSection('gist-debug-user-label', 'gist-debug-user-value'));
+
+  // Route section
+  const routeSection = el('div', { className: 'gist-debug-section' });
+  const routeLabel = el('div', { className: 'gist-debug-label' });
+  routeLabel.appendChild(el('span', { textContent: 'Route' }));
+  routeSection.appendChild(routeLabel);
+  routeSection.appendChild(
+    el('div', { className: 'gist-debug-value', id: 'gist-debug-route-value' })
+  );
+  const inlineCode = el('code', {
+    className: 'gist-debug-inline-code',
+    textContent: 'analytics.page()',
+  });
+  const routeDetail = buildExpandDetail([
+    'The current route is used to match against message page rules if set.',
+    [
+      document.createTextNode('For single-page applications, ensure '),
+      inlineCode,
+      document.createTextNode(' is called on every route change'),
+    ],
+  ]);
+  routeSection.appendChild(routeDetail);
+  overlay.appendChild(routeSection);
+
+  overlay.appendChild(
+    buildSection('gist-debug-messages-label', undefined, 'gist-debug-messages-list')
+  );
+  return overlay;
+}
+
+function buildKvRow(key: string, value: string, error = false): HTMLElement {
+  const row = el('div', { className: 'gist-debug-msg-row' });
+  row.appendChild(el('span', { className: 'gist-debug-msg-key', textContent: key }));
+  row.appendChild(
+    el('span', {
+      className: error ? 'gist-debug-msg-val gist-debug-val-error' : 'gist-debug-msg-val',
+      textContent: value,
+    })
+  );
+  return row;
+}
+
+function renderKv(container: HTMLElement, pairs: Array<[string, string]>, error = false): void {
+  container.innerHTML = '';
+  for (const [key, value] of pairs) container.appendChild(buildKvRow(key, value, error));
+}
+
+function refreshSync(): void {
+  if (!document.getElementById(OVERLAY_ID)) return;
+
+  // Config + init status
+  const configRows = document.getElementById('gist-debug-config-rows');
+  if (configRows) {
+    if (!Gist.config) {
+      renderKv(configRows, [['Status', 'NOT INITIALIZED']], true);
+    } else {
+      renderKv(configRows, [
+        ['Status', 'INITIALIZED'],
+        ['Connection', settings.useSSE() ? 'SSE' : 'polling'],
+        ['Site ID', `${Gist.config.siteId.slice(0, 3)}…`],
+      ]);
+    }
+  }
+
+  // User
+  const userLabel = document.getElementById('gist-debug-user-label');
+  const userValue = document.getElementById('gist-debug-user-value');
+  if (userLabel && userValue) {
+    userLabel.textContent = 'User';
+    const token = getUserToken();
+    if (!token) {
+      userValue.textContent = '(none)';
+    } else if (isUsingGuestUserToken()) {
+      userValue.textContent = '(anonymous)';
+    } else {
+      userValue.textContent = token.length > 32 ? `${token.slice(0, 32)}…` : token;
+    }
+  }
+
+  // Route — value only, label and detail are static DOM from buildOverlay
+  const routeValue = document.getElementById('gist-debug-route-value');
+  if (routeValue) {
+    const route = Gist.currentRoute;
+    routeValue.innerHTML = '';
+    routeValue.appendChild(
+      el('span', {
+        className: route ? 'gist-debug-msg-val' : 'gist-debug-msg-val gist-debug-val-error',
+        textContent: route ?? 'NONE',
+      })
+    );
+  }
+}
+
+async function refreshMessages(): Promise<void> {
+  if (!document.getElementById(OVERLAY_ID)) return;
+  const label = document.getElementById('gist-debug-messages-label');
+  const list = document.getElementById('gist-debug-messages-list');
+  if (!label || !list) return;
+
+  const active = Gist.currentMessages ?? [];
+  const [userMsgs, broadcasts] = Gist.config
+    ? await Promise.all([getMessagesFromLocalStore(), getEligibleBroadcasts()])
+    : [[], []];
+  const queued = [...broadcasts, ...userMsgs];
+  const total = active.length + queued.length;
+
+  label.textContent = `Messages (${total})`;
+  list.innerHTML = '';
+  for (const msg of active) list.appendChild(buildMessageEl(msg, 'active'));
+  for (const msg of queued) list.appendChild(buildMessageEl(msg, 'queued'));
+}
+
+// Lazily subscribe to Gist events and patch setCurrentRoute. Called on each
+// poll tick until Gist.events is available (Gist.setup() may run after load).
+function subscribeEvents(): void {
+  if (eventsSubscribed || !Gist.events) return;
+  Gist.events.on('messageShown', () => {
+    refreshSync();
+    void refreshMessages();
+  });
+  Gist.events.on('messageDismissed', () => {
+    refreshSync();
+    void refreshMessages();
+  });
+  Gist.events.on('messageInboxUpdated', () => {
+    void refreshMessages();
+  });
+
+  // No route-changed event exists — intercept setCurrentRoute instead.
+  const originalSetCurrentRoute = Gist.setCurrentRoute.bind(Gist);
+  Gist.setCurrentRoute = async (route: string) => {
+    await originalSetCurrentRoute(route);
+    refreshSync();
+    void refreshMessages();
+  };
+
+  eventsSubscribed = true;
+}
+
+async function refreshAll(): Promise<void> {
+  subscribeEvents();
+  refreshSync();
+  await refreshMessages();
+}
+
+export function initDebugOverlay(): void {
+  if (document.getElementById(OVERLAY_ID)) return;
+  injectStylesheet(STYLE_ID, DEBUG_OVERLAY_CSS);
+  const overlay = buildOverlay();
+  appendToBody(overlay);
+  void refreshAll();
+  pollIntervalId = setInterval(() => void refreshAll(), POLL_INTERVAL_MS);
+}

--- a/src/managers/debug-overlay-manager.ts
+++ b/src/managers/debug-overlay-manager.ts
@@ -1,6 +1,5 @@
 import Gist from '../gist';
 import { el, findElement, injectStylesheet, appendToBody } from '../utilities/dom';
-import { version as SDK_VERSION } from '../../package.json';
 import { DEBUG_OVERLAY_CSS } from './debug-overlay-styles';
 import { getMessagesFromLocalStore } from './message-user-queue-manager';
 import { getEligibleBroadcasts } from './message-broadcast-manager';
@@ -30,7 +29,6 @@ let refs: OverlayRefs | null = null;
 let eventsSubscribed = false;
 let refreshing = false;
 let pollIntervalId: ReturnType<typeof setInterval> | null = null;
-let originalSetCurrentRoute: typeof Gist.setCurrentRoute | null = null;
 
 function getDebugDisplayType(msg: GistMessage): ReturnType<typeof getCurrentDisplayType> {
   const gist = msg.properties?.gist;
@@ -171,7 +169,7 @@ function buildOverlay(): OverlayRefs {
   header.appendChild(
     el('span', {
       className: 'gist-debug-title',
-      textContent: `Customer.io In-App SDK ${SDK_VERSION}`,
+      textContent: 'Customer.io In-App SDK Debugger',
     })
   );
   const closeBtn = el('button', {
@@ -296,6 +294,8 @@ async function refreshMessages(): Promise<void> {
       seen.add(id);
       return true;
     });
+    if (!refs) return;
+
     const total = active.length + queued.length;
 
     refs.messagesLabel.textContent = `Messages (${total})`;
@@ -322,12 +322,7 @@ function subscribeEvents(): void {
   Gist.events.on('messageShown', onMessageChanged);
   Gist.events.on('messageDismissed', onMessageChanged);
   Gist.events.on('messageInboxUpdated', onInboxUpdated);
-
-  originalSetCurrentRoute = Gist.setCurrentRoute.bind(Gist);
-  Gist.setCurrentRoute = async (route: string) => {
-    await originalSetCurrentRoute!(route);
-    onMessageChanged();
-  };
+  Gist.events.on('routeChanged', onMessageChanged);
 
   eventsSubscribed = true;
 }
@@ -338,10 +333,7 @@ function unsubscribeEvents(): void {
     Gist.events.off('messageShown', onMessageChanged);
     Gist.events.off('messageDismissed', onMessageChanged);
     Gist.events.off('messageInboxUpdated', onInboxUpdated);
-  }
-  if (originalSetCurrentRoute) {
-    Gist.setCurrentRoute = originalSetCurrentRoute;
-    originalSetCurrentRoute = null;
+    Gist.events.off('routeChanged', onMessageChanged);
   }
   eventsSubscribed = false;
 }

--- a/src/managers/debug-overlay-manager.ts
+++ b/src/managers/debug-overlay-manager.ts
@@ -17,6 +17,7 @@ const POLL_INTERVAL_MS = 2000;
 
 let eventsSubscribed = false;
 let pollIntervalId: ReturnType<typeof setInterval> | null = null;
+let originalSetCurrentRoute: typeof Gist.setCurrentRoute | null = null;
 
 function getDebugDisplayType(msg: GistMessage): 'modal' | 'overlay' | 'inline' | 'tooltip' {
   const gist = msg.properties?.gist;
@@ -59,7 +60,7 @@ function routeRuleMismatches(rule: string): boolean {
     const matchesPathname = Gist.currentRoute !== pathname && re.test(pathname);
     return !matchesCurrent && !matchesPathname;
   } catch {
-    return false;
+    return true;
   }
 }
 
@@ -176,6 +177,7 @@ function buildOverlay(): HTMLElement {
       clearInterval(pollIntervalId);
       pollIntervalId = null;
     }
+    unsubscribeEvents();
   });
   header.appendChild(closeBtn);
   overlay.appendChild(header);
@@ -299,9 +301,13 @@ async function refreshMessages(): Promise<void> {
     ? await Promise.all([getMessagesFromLocalStore(), getEligibleBroadcasts()])
     : [[], []];
   const activeIds = new Set(active.map((m) => m.queueId ?? m.messageId));
-  const queued = [...broadcasts, ...userMsgs].filter(
-    (m) => !activeIds.has(m.queueId ?? m.messageId)
-  );
+  const seen = new Set<string>();
+  const queued = [...broadcasts, ...userMsgs].filter((m) => {
+    const id = m.queueId ?? m.messageId;
+    if (activeIds.has(id) || seen.has(id)) return false;
+    seen.add(id);
+    return true;
+  });
   const total = active.length + queued.length;
 
   label.textContent = `Messages (${total})`;
@@ -310,31 +316,46 @@ async function refreshMessages(): Promise<void> {
   for (const msg of queued) list.appendChild(buildMessageEl(msg, 'queued'));
 }
 
+function onMessageChanged(): void {
+  refreshSync();
+  void refreshMessages();
+}
+
+function onInboxUpdated(): void {
+  void refreshMessages();
+}
+
 // Lazily subscribe to Gist events and patch setCurrentRoute. Called on each
 // poll tick until Gist.events is available (Gist.setup() may run after load).
 function subscribeEvents(): void {
   if (eventsSubscribed || !Gist.events) return;
-  Gist.events.on('messageShown', () => {
-    refreshSync();
-    void refreshMessages();
-  });
-  Gist.events.on('messageDismissed', () => {
-    refreshSync();
-    void refreshMessages();
-  });
-  Gist.events.on('messageInboxUpdated', () => {
-    void refreshMessages();
-  });
+  Gist.events.on('messageShown', onMessageChanged);
+  Gist.events.on('messageDismissed', onMessageChanged);
+  Gist.events.on('messageInboxUpdated', onInboxUpdated);
 
   // No route-changed event exists — intercept setCurrentRoute instead.
-  const originalSetCurrentRoute = Gist.setCurrentRoute.bind(Gist);
+  originalSetCurrentRoute = Gist.setCurrentRoute.bind(Gist);
   Gist.setCurrentRoute = async (route: string) => {
-    await originalSetCurrentRoute(route);
+    await originalSetCurrentRoute!(route);
     refreshSync();
     void refreshMessages();
   };
 
   eventsSubscribed = true;
+}
+
+function unsubscribeEvents(): void {
+  if (!eventsSubscribed) return;
+  if (Gist.events) {
+    Gist.events.off('messageShown', onMessageChanged);
+    Gist.events.off('messageDismissed', onMessageChanged);
+    Gist.events.off('messageInboxUpdated', onInboxUpdated);
+  }
+  if (originalSetCurrentRoute) {
+    Gist.setCurrentRoute = originalSetCurrentRoute;
+    originalSetCurrentRoute = null;
+  }
+  eventsSubscribed = false;
 }
 
 async function refreshAll(): Promise<void> {

--- a/src/managers/debug-overlay-manager.ts
+++ b/src/managers/debug-overlay-manager.ts
@@ -64,10 +64,6 @@ function msgProps(msg: GistMessage): Array<[string, string]> {
   return pairs;
 }
 
-function routeRuleMismatches(rule: string): boolean {
-  return !matchesRouteRule(rule);
-}
-
 function buildKvRow(key: string, value: string, error = false): HTMLElement {
   const row = el('div', { className: 'gist-debug-msg-row' });
   row.appendChild(el('span', { className: 'gist-debug-msg-key', textContent: key }));
@@ -116,7 +112,7 @@ function buildMessageEl(msg: GistMessage, state: 'active' | 'queued'): HTMLEleme
     let statusText: string | null = null;
 
     if (key === 'Route Rule') {
-      const mismatch = routeRuleMismatches(value);
+      const mismatch = !matchesRouteRule(value);
       statusClass = mismatch ? 'gist-debug-route-mismatch' : 'gist-debug-element-found';
       statusText = mismatch ? '✕' : '✓';
       if (mismatch)

--- a/src/managers/debug-overlay-manager.ts
+++ b/src/managers/debug-overlay-manager.ts
@@ -1,5 +1,5 @@
 import Gist from '../gist';
-import { el, injectStylesheet, appendToBody } from '../utilities/dom';
+import { el, findElement, injectStylesheet, appendToBody } from '../utilities/dom';
 import { version as SDK_VERSION } from '../../package.json';
 import { DEBUG_OVERLAY_CSS } from './debug-overlay-styles';
 import { getMessagesFromLocalStore } from './message-user-queue-manager';
@@ -103,7 +103,7 @@ function buildMessageEl(msg: GistMessage, state: 'active' | 'queued'): HTMLEleme
           'Route rule does not match current route. If it should, verify the route is set correctly and that analytics.page() is called on route changes.'
         );
     } else if (key === 'target') {
-      const exists = !!(document.getElementById(value) ?? document.querySelector(value));
+      const exists = !!findElement(value);
       statusClass = exists ? 'gist-debug-element-found' : 'gist-debug-route-mismatch';
       statusText = exists ? '✓' : '✕';
       if (!exists)
@@ -341,7 +341,7 @@ async function refreshAll(): Promise<void> {
 }
 
 export function initDebugOverlay(): void {
-  if (document.getElementById(OVERLAY_ID)) return;
+  if (pollIntervalId !== null) return;
   injectStylesheet(STYLE_ID, DEBUG_OVERLAY_CSS);
   const overlay = buildOverlay();
   appendToBody(overlay);

--- a/src/managers/debug-overlay-manager.ts
+++ b/src/managers/debug-overlay-manager.ts
@@ -6,7 +6,11 @@ import { getEligibleBroadcasts } from './message-broadcast-manager';
 import { getUserToken, isUsingGuestUserToken } from './user-manager';
 import { settings } from '../services/settings';
 import { getPollingIntervalSeconds } from '../services/queue-service';
-import { mapElementIdToOverlayPosition, getCurrentDisplayType } from '../utilities/message-utils';
+import {
+  mapElementIdToOverlayPosition,
+  getCurrentDisplayType,
+  matchesRouteRule,
+} from '../utilities/message-utils';
 
 import type { GistMessage } from '../types';
 
@@ -61,15 +65,7 @@ function msgProps(msg: GistMessage): Array<[string, string]> {
 }
 
 function routeRuleMismatches(rule: string): boolean {
-  try {
-    const re = new RegExp(rule);
-    const pathname = new URL(window.location.href).pathname;
-    const matchesCurrent = Gist.currentRoute != null && re.test(Gist.currentRoute);
-    const matchesPathname = Gist.currentRoute !== pathname && re.test(pathname);
-    return !matchesCurrent && !matchesPathname;
-  } catch {
-    return true;
-  }
+  return !matchesRouteRule(rule);
 }
 
 function buildKvRow(key: string, value: string, error = false): HTMLElement {

--- a/src/managers/debug-overlay-manager.ts
+++ b/src/managers/debug-overlay-manager.ts
@@ -298,7 +298,10 @@ async function refreshMessages(): Promise<void> {
   const [userMsgs, broadcasts] = Gist.config
     ? await Promise.all([getMessagesFromLocalStore(), getEligibleBroadcasts()])
     : [[], []];
-  const queued = [...broadcasts, ...userMsgs];
+  const activeIds = new Set(active.map((m) => m.queueId ?? m.messageId));
+  const queued = [...broadcasts, ...userMsgs].filter(
+    (m) => !activeIds.has(m.queueId ?? m.messageId)
+  );
   const total = active.length + queued.length;
 
   label.textContent = `Messages (${total})`;

--- a/src/managers/debug-overlay-manager.ts
+++ b/src/managers/debug-overlay-manager.ts
@@ -5,9 +5,8 @@ import { DEBUG_OVERLAY_CSS } from './debug-overlay-styles';
 import { getMessagesFromLocalStore } from './message-user-queue-manager';
 import { getEligibleBroadcasts } from './message-broadcast-manager';
 import { getUserToken, isUsingGuestUserToken } from './user-manager';
-import { positions } from './page-component-manager';
 import { settings } from '../services/settings';
-import { mapElementIdToOverlayPosition } from '../utilities/message-utils';
+import { mapElementIdToOverlayPosition, getCurrentDisplayType } from '../utilities/message-utils';
 
 import type { GistMessage } from '../types';
 
@@ -19,14 +18,14 @@ let eventsSubscribed = false;
 let pollIntervalId: ReturnType<typeof setInterval> | null = null;
 let originalSetCurrentRoute: typeof Gist.setCurrentRoute | null = null;
 
-function getDebugDisplayType(msg: GistMessage): 'modal' | 'overlay' | 'inline' | 'tooltip' {
+function getDebugDisplayType(msg: GistMessage): ReturnType<typeof getCurrentDisplayType> {
   const gist = msg.properties?.gist;
-  const tooltipPos = gist?.tooltipPosition ?? msg.tooltipPosition;
-  if (tooltipPos) return 'tooltip';
-  const elementId = gist?.elementId ?? msg.elementId;
-  if (elementId && positions.includes(String(elementId))) return 'overlay';
-  if (elementId) return 'inline';
-  return 'modal';
+  if (!gist) return getCurrentDisplayType(msg);
+  return getCurrentDisplayType({
+    ...msg,
+    tooltipPosition: gist.tooltipPosition ?? msg.tooltipPosition,
+    elementId: gist.elementId != null ? String(gist.elementId) : msg.elementId,
+  });
 }
 
 function formatOverlayPositionLabel(overlayPosition: string): string {

--- a/src/managers/debug-overlay-styles.ts
+++ b/src/managers/debug-overlay-styles.ts
@@ -1,0 +1,197 @@
+export const DEBUG_OVERLAY_CSS = `
+  #gist-debug-overlay {
+    position: fixed; bottom: 16px; right: 16px;
+    z-index: 99999999999;
+    background: #08272B; color: white;
+    font-family: system-ui, -apple-system, sans-serif;
+    font-size: 11px;
+    border-radius: 8px;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+    width: 300px;
+    max-height: min(700px, calc(100vh - 32px));
+    display: flex;
+    flex-direction: column;
+    pointer-events: auto;
+    overflow: hidden;
+  }
+  .gist-debug-header {
+    display: flex; align-items: center;
+    padding: 8px 12px;
+    border-bottom: 1px solid rgba(255,255,255,0.1);
+    flex-shrink: 0;
+  }
+  .gist-debug-title {
+    flex: 1;
+    font-weight: 700;
+    font-size: 12px;
+    letter-spacing: 0.02em;
+  }
+  #gist-debug-overlay-close {
+    background: none; border: none;
+    color: white; cursor: pointer;
+    padding: 0; font-size: 18px; line-height: 1;
+    opacity: 0.6; flex-shrink: 0;
+    font-family: system-ui, -apple-system, sans-serif;
+    -webkit-appearance: none; appearance: none;
+  }
+  #gist-debug-overlay-close:hover { opacity: 1; }
+  .gist-debug-section {
+    padding: 0 12px 8px;
+    border-bottom: 1px solid rgba(255,255,255,0.07);
+    overflow-y: auto;
+    max-height: 180px;
+  }
+  .gist-debug-section:last-child { border-bottom: none; }
+  .gist-debug-label {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background: #08272B;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgba(255,255,255,0.45);
+    padding: 8px 0 5px;
+    font-weight: 600;
+  }
+  .gist-debug-value {
+    font-family: 'SF Mono', 'Monaco', 'Consolas', monospace;
+    font-size: 11px;
+    color: rgba(255,255,255,0.9);
+    overflow-wrap: break-word;
+  }
+  .gist-debug-msg {
+    background: rgba(255,255,255,0.06);
+    border-radius: 4px;
+    padding: 5px 7px;
+    margin-bottom: 4px;
+  }
+  .gist-debug-msg:last-child { margin-bottom: 0; }
+  .gist-debug-msg-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 2px;
+  }
+  .gist-debug-msg-row:last-child { margin-bottom: 0; }
+  .gist-debug-msg-meta {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    margin-bottom: 4px;
+  }
+  .gist-debug-msg-state {
+    font-size: 9px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    border-radius: 3px;
+    padding: 1px 4px;
+    flex-shrink: 0;
+  }
+  .gist-debug-msg-state--active {
+    color: #4caf82;
+    background: rgba(76,175,130,0.12);
+  }
+  .gist-debug-msg-state--queued {
+    color: rgba(255,200,100,0.9);
+    background: rgba(255,200,100,0.1);
+  }
+  .gist-debug-msg-dismiss {
+    margin-left: auto;
+    background: none;
+    border: none;
+    color: rgba(255,255,255,0.3);
+    cursor: pointer;
+    padding: 0;
+    font-size: 13px;
+    line-height: 1;
+    font-family: system-ui, -apple-system, sans-serif;
+    -webkit-appearance: none;
+    appearance: none;
+  }
+  .gist-debug-msg-dismiss:hover { color: rgba(255,255,255,0.7); }
+  .gist-debug-element-found {
+    color: #4caf82;
+    font-size: 9px;
+    font-weight: 700;
+    flex-shrink: 0;
+  }
+  .gist-debug-route-mismatch {
+    color: #ff6b6b;
+    font-size: 9px;
+    font-weight: 700;
+    flex-shrink: 0;
+  }
+  .gist-debug-msg-type {
+    font-size: 9px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: rgba(255,255,255,0.45);
+    background: rgba(255,255,255,0.08);
+    border-radius: 3px;
+    padding: 1px 4px;
+    flex-shrink: 0;
+  }
+  .gist-debug-msg-key {
+    color: rgba(255,255,255,0.45);
+    font-size: 10px;
+    line-height: 1.4;
+    min-width: 64px;
+    flex-shrink: 0;
+  }
+  .gist-debug-msg-val {
+    font-family: 'SF Mono', 'Monaco', 'Consolas', monospace;
+    font-size: 10px;
+    line-height: 1.4;
+    color: rgba(255,255,255,0.9);
+    overflow-wrap: break-word;
+  }
+  .gist-debug-val-error {
+    color: #ff6b6b;
+    font-weight: 600;
+  }
+  .gist-debug-expand-detail {
+    background: rgba(255,107,107,0.08);
+    border-left: 2px solid rgba(255,107,107,0.4);
+    color: rgba(255,255,255,0.75);
+    font-family: system-ui, -apple-system, sans-serif;
+    font-size: 10px;
+    padding: 4px 6px;
+    margin-top: 4px;
+    margin-bottom: 6px;
+    border-radius: 0 3px 3px 0;
+  }
+  .gist-debug-expand-list {
+    margin: 0;
+    padding: 0 0 0 14px;
+    list-style: disc;
+  }
+  .gist-debug-expand-list li {
+    margin-bottom: 3px;
+    line-height: 1.4;
+  }
+  .gist-debug-expand-list li:last-child { margin-bottom: 0; }
+  .gist-debug-msg-details {
+    margin: 5px 0 0;
+    padding: 0 0 0 14px;
+    list-style: disc;
+    color: rgba(255,255,255,0.5);
+    font-size: 10px;
+    line-height: 1.4;
+    font-family: system-ui, -apple-system, sans-serif;
+  }
+  .gist-debug-msg-details li { margin-bottom: 2px; }
+  .gist-debug-msg-details li:last-child { margin-bottom: 0; }
+  .gist-debug-inline-code {
+    font-family: 'SF Mono', 'Monaco', 'Consolas', monospace;
+    font-size: 9px;
+    background: rgba(255,255,255,0.1);
+    padding: 1px 3px;
+    border-radius: 2px;
+  }
+`;

--- a/src/managers/debug-overlay-styles.ts
+++ b/src/managers/debug-overlay-styles.ts
@@ -67,7 +67,7 @@ export const DEBUG_OVERLAY_CSS = `
     background: rgba(255,255,255,0.06);
     border-radius: 4px;
     padding: 5px 7px;
-    margin-bottom: 4px;
+    margin-bottom: 8px;
   }
   .gist-debug-msg:last-child { margin-bottom: 0; }
   .gist-debug-msg-row {
@@ -187,11 +187,4 @@ export const DEBUG_OVERLAY_CSS = `
   }
   .gist-debug-msg-details li { margin-bottom: 2px; }
   .gist-debug-msg-details li:last-child { margin-bottom: 0; }
-  .gist-debug-inline-code {
-    font-family: 'SF Mono', 'Monaco', 'Consolas', monospace;
-    font-size: 9px;
-    background: rgba(255,255,255,0.1);
-    padding: 1px 3px;
-    border-radius: 2px;
-  }
 `;

--- a/src/managers/preview-bar-manager.ts
+++ b/src/managers/preview-bar-manager.ts
@@ -8,7 +8,7 @@ import {
   mapOverlayPositionToElementId,
 } from '../utilities/message-utils';
 import { log } from '../utilities/log';
-import { findElement } from '../utilities/dom';
+import { findElement, el, injectStylesheet } from '../utilities/dom';
 import { PREVIEW_BAR_CSS, chevronSvg } from './preview-bar-styles';
 import { savePreviewDisplaySettings, deletePreviewSession } from '../services/preview-service';
 import { PREVIEW_PARAM_ID, teardownPreview } from '../utilities/preview-mode';
@@ -25,14 +25,6 @@ const OVERLAY_POSITION_LABELS: Record<string, string> = {
   bottomCenter: 'Bottom Center',
   bottomRight: 'Bottom Right',
 };
-
-function injectStyles(): void {
-  if (document.getElementById(STYLE_ID)) return;
-  const style = document.createElement('style');
-  style.id = STYLE_ID;
-  style.textContent = PREVIEW_BAR_CSS;
-  document.head.appendChild(style);
-}
 
 // ─── Module state ─────────────────────────────────────────────────────────────
 
@@ -54,19 +46,6 @@ let pendingInitialDisplayType: string | null = null;
 // keyed by CSS selector. Only captured once per selector so re-visits always restore
 // to the true pre-message state.
 const originalElementContent = new Map<string, string>();
-
-// ─── DOM helper ───────────────────────────────────────────────────────────────
-
-function el<K extends keyof HTMLElementTagNameMap>(
-  tag: K,
-  attrs: Partial<HTMLElementTagNameMap[K]> & { [k: string]: unknown } = {}
-): HTMLElementTagNameMap[K] {
-  const element = document.createElement(tag);
-  for (const [k, v] of Object.entries(attrs)) {
-    (element as Record<string, unknown>)[k] = v;
-  }
-  return element;
-}
 
 function labelGroup(labelText: string, control: HTMLElement): HTMLElement {
   const wrapper = el('div', { className: 'gist-pb-label-group' });
@@ -763,7 +742,7 @@ function toggleCollapse() {
 
 export function initPreviewBar(): void {
   if (document.getElementById(BAR_ID)) return;
-  injectStyles();
+  injectStylesheet(STYLE_ID, PREVIEW_BAR_CSS);
   try {
     isCollapsed = sessionStorage.getItem(STORAGE_KEY) === 'true';
   } catch {

--- a/src/managers/queue-manager.test.ts
+++ b/src/managers/queue-manager.test.ts
@@ -91,9 +91,13 @@ vi.mock('../services/settings', () => ({
     },
   },
 }));
-vi.mock('../utilities/message-utils', () => ({
-  applyDisplaySettings: vi.fn(),
-}));
+vi.mock('../utilities/message-utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../utilities/message-utils')>();
+  return {
+    ...actual,
+    applyDisplaySettings: vi.fn(),
+  };
+});
 vi.mock('../utilities/dom', () => ({
   findElement: vi.fn(() => null),
 }));

--- a/src/managers/queue-manager.ts
+++ b/src/managers/queue-manager.ts
@@ -90,11 +90,18 @@ export async function checkCurrentMessagesAfterRouteChange(): Promise<void> {
 // TODO: Move this to a utility and only return valid messages (from: getEligibleBroadcasts getMessagesFromLocalStore) & to handleMessage
 export async function handleMessage(message: GistMessage): Promise<boolean> {
   let messageProperties = resolveMessageProperties(message);
-  if (messageProperties.hasRouteRule && !matchesRouteRule(messageProperties.routeRule)) {
-    log(
-      `Route ${new URL(window.location.href).pathname} (currentRoute: ${Gist.currentRoute}) does not match rule: ${messageProperties.routeRule}`
-    );
-    return false;
+  if (messageProperties.hasRouteRule) {
+    if (Gist.currentRoute == null && document.readyState === 'loading') {
+      log(`Deferring message ${message.queueId}, page not fully loaded`);
+      return false;
+    }
+
+    if (!matchesRouteRule(messageProperties.routeRule)) {
+      log(
+        `Route ${new URL(window.location.href).pathname} (currentRoute: ${Gist.currentRoute}) does not match rule: ${messageProperties.routeRule}`
+      );
+      return false;
+    }
   }
 
   if (messageProperties.hasPosition) {

--- a/src/managers/queue-manager.ts
+++ b/src/managers/queue-manager.ts
@@ -25,7 +25,7 @@ import {
 import { updateInboxMessagesLocalStore } from './inbox-message-manager';
 import type { InboxMessage } from './inbox-message-manager';
 import { settings } from '../services/settings';
-import { applyDisplaySettings } from '../utilities/message-utils';
+import { applyDisplaySettings, matchesRouteRule } from '../utilities/message-utils';
 import { findElement } from '../utilities/dom';
 import type { GistMessage, DisplaySettings } from '../types';
 
@@ -90,30 +90,11 @@ export async function checkCurrentMessagesAfterRouteChange(): Promise<void> {
 // TODO: Move this to a utility and only return valid messages (from: getEligibleBroadcasts getMessagesFromLocalStore) & to handleMessage
 export async function handleMessage(message: GistMessage): Promise<boolean> {
   let messageProperties = resolveMessageProperties(message);
-  if (messageProperties.hasRouteRule) {
-    const routeRule = new RegExp(messageProperties.routeRule);
-    const pathname = new URL(window.location.href).pathname;
-
-    // Route rule evaluation checks two values.
-    //
-    // Gist.currentRoute (primary): Set by the SDK's analytics.page() call. This is
-    // what customers have historically built their rules against. The value varies
-    // by call style — analytics.page("Name") sets an arbitrary string like "Name",
-    // analytics.page() sets the full URL, and never calling it leaves currentRoute
-    // null. Existing customers have live rules that depend on all of these formats.
-    //
-    // pathname (fallback): The URL path from window.location. Always available and
-    // always a path like "/dashboard", regardless of how analytics.page() was called.
-    // Catches cases where currentRoute is null or set to a value that doesn't match.
-    const matchesCurrentRoute = Gist.currentRoute != null && routeRule.test(Gist.currentRoute);
-    const matchesPathname = Gist.currentRoute !== pathname && routeRule.test(pathname);
-
-    if (!matchesCurrentRoute && !matchesPathname) {
-      log(
-        `Route ${pathname} (currentRoute: ${Gist.currentRoute}) does not match rule: ${messageProperties.routeRule}`
-      );
-      return false;
-    }
+  if (messageProperties.hasRouteRule && !matchesRouteRule(messageProperties.routeRule)) {
+    log(
+      `Route ${new URL(window.location.href).pathname} (currentRoute: ${Gist.currentRoute}) does not match rule: ${messageProperties.routeRule}`
+    );
+    return false;
   }
 
   if (messageProperties.hasPosition) {

--- a/src/services/queue-service.ts
+++ b/src/services/queue-service.ts
@@ -108,3 +108,7 @@ export function getQueueSSEEndpoint(): string | null {
     `/api/v3/sse?userToken=${encodedUserToken}&siteId=${Gist.config.siteId}&sessionId=${getSessionId()}`
   );
 }
+
+export function getPollingIntervalSeconds(): number {
+  return currentPollingDelayInSeconds;
+}

--- a/src/utilities/debug-mode.ts
+++ b/src/utilities/debug-mode.ts
@@ -1,0 +1,16 @@
+import { initDebugOverlay } from '../managers/debug-overlay-manager';
+import { log } from './log';
+
+export const DEBUG_SESSION_PARAM = 'cio_debug_session';
+
+export function setupDebugOverlay(): void {
+  if (typeof window === 'undefined') return;
+  if (new URLSearchParams(window.location.search).get(DEBUG_SESSION_PARAM) !== 'true') return;
+
+  try {
+    initDebugOverlay();
+  } catch (error) {
+    // Fail silently if the debug overlay fails to initialize, as it should not impact the main functionality of the SDK
+    log(`Failed to initialize debug overlay: ${error}`);
+  }
+}

--- a/src/utilities/debug-mode.ts
+++ b/src/utilities/debug-mode.ts
@@ -10,7 +10,6 @@ export function setupDebugOverlay(): void {
   try {
     initDebugOverlay();
   } catch (error) {
-    // Fail silently if the debug overlay fails to initialize, as it should not impact the main functionality of the SDK
     log(`Failed to initialize debug overlay: ${error}`);
   }
 }

--- a/src/utilities/dom.ts
+++ b/src/utilities/dom.ts
@@ -6,3 +6,32 @@ export function findElement(selector: string): HTMLElement | null {
     return null;
   }
 }
+
+export function el<K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  attrs: Partial<HTMLElementTagNameMap[K]> & { [k: string]: unknown } = {}
+): HTMLElementTagNameMap[K] {
+  const element = document.createElement(tag);
+  for (const [k, v] of Object.entries(attrs)) {
+    (element as Record<string, unknown>)[k] = v;
+  }
+  return element;
+}
+
+export function injectStylesheet(id: string, css: string): void {
+  if (document.getElementById(id)) return;
+  const style = document.createElement('style');
+  style.id = id;
+  style.textContent = css;
+  document.head.appendChild(style);
+}
+
+export function appendToBody(element: HTMLElement): void {
+  if (document.body) {
+    document.body.appendChild(element);
+  } else {
+    document.addEventListener('DOMContentLoaded', () => document.body.appendChild(element), {
+      once: true,
+    });
+  }
+}

--- a/src/utilities/message-utils.ts
+++ b/src/utilities/message-utils.ts
@@ -76,6 +76,9 @@ export function mapElementIdToOverlayPosition(
 
 export function matchesRouteRule(rule: string): boolean {
   try {
+    const routeRule = new RegExp(rule);
+    const pathname = new URL(window.location.href).pathname;
+
     // Route rule evaluation checks two values.
     //
     // Gist.currentRoute (primary): Set by the SDK's analytics.page() call. This is
@@ -88,8 +91,6 @@ export function matchesRouteRule(rule: string): boolean {
     // always a path like "/dashboard", regardless of how analytics.page() was called.
     // Catches cases where currentRoute is null or set to a value that doesn't match.
 
-    const routeRule = new RegExp(rule);
-    const pathname = new URL(window.location.href).pathname;
     const matchesCurrentRoute = Gist.currentRoute != null && routeRule.test(Gist.currentRoute);
     const matchesPathname = Gist.currentRoute !== pathname && routeRule.test(pathname);
     return matchesCurrentRoute || matchesPathname;

--- a/src/utilities/message-utils.ts
+++ b/src/utilities/message-utils.ts
@@ -74,6 +74,30 @@ export function mapElementIdToOverlayPosition(
   return ELEMENT_ID_TO_OVERLAY_POSITION[elementId];
 }
 
+export function matchesRouteRule(rule: string): boolean {
+  try {
+    // Route rule evaluation checks two values.
+    //
+    // Gist.currentRoute (primary): Set by the SDK's analytics.page() call. This is
+    // what customers have historically built their rules against. The value varies
+    // by call style — analytics.page("Name") sets an arbitrary string like "Name",
+    // analytics.page() sets the full URL, and never calling it leaves currentRoute
+    // null. Existing customers have live rules that depend on all of these formats.
+    //
+    // pathname (fallback): The URL path from window.location. Always available and
+    // always a path like "/dashboard", regardless of how analytics.page() was called.
+    // Catches cases where currentRoute is null or set to a value that doesn't match.
+
+    const routeRule = new RegExp(rule);
+    const pathname = new URL(window.location.href).pathname;
+    const matchesCurrentRoute = Gist.currentRoute != null && routeRule.test(Gist.currentRoute);
+    const matchesPathname = Gist.currentRoute !== pathname && routeRule.test(pathname);
+    return matchesCurrentRoute || matchesPathname;
+  } catch {
+    return false;
+  }
+}
+
 export function getCurrentDisplayType(
   message: GistMessage
 ): 'modal' | 'overlay' | 'inline' | 'tooltip' {

--- a/src/utilities/message-utils.ts
+++ b/src/utilities/message-utils.ts
@@ -45,22 +45,33 @@ export function updateMessageByInstanceId(instanceId: string, message: GistMessa
   Gist.currentMessages.push(message);
 }
 
-export function mapOverlayPositionToElementId(overlayPosition: string | undefined): string {
-  const positionMap: Record<string, string> = {
-    topLeft: 'x-gist-floating-top-left',
-    topCenter: 'x-gist-floating-top',
-    topRight: 'x-gist-floating-top-right',
-    bottomLeft: 'x-gist-floating-bottom-left',
-    bottomCenter: 'x-gist-floating-bottom',
-    bottomRight: 'x-gist-floating-bottom-right',
-  };
+const OVERLAY_POSITION_TO_ELEMENT_ID: Record<string, string> = {
+  topLeft: 'x-gist-floating-top-left',
+  topCenter: 'x-gist-floating-top',
+  topRight: 'x-gist-floating-top-right',
+  bottomLeft: 'x-gist-floating-bottom-left',
+  bottomCenter: 'x-gist-floating-bottom',
+  bottomRight: 'x-gist-floating-bottom-right',
+};
 
-  if (!overlayPosition || !positionMap[overlayPosition]) {
+const ELEMENT_ID_TO_OVERLAY_POSITION: Record<string, string> = Object.fromEntries(
+  Object.entries(OVERLAY_POSITION_TO_ELEMENT_ID).map(([key, value]) => [value, key])
+);
+
+export function mapOverlayPositionToElementId(overlayPosition: string | undefined): string {
+  if (!overlayPosition || !OVERLAY_POSITION_TO_ELEMENT_ID[overlayPosition]) {
     log(`Invalid overlay position "${overlayPosition}", defaulting to "topCenter"`);
-    return positionMap['topCenter'];
+    return OVERLAY_POSITION_TO_ELEMENT_ID['topCenter'];
   }
 
-  return positionMap[overlayPosition];
+  return OVERLAY_POSITION_TO_ELEMENT_ID[overlayPosition];
+}
+
+export function mapElementIdToOverlayPosition(
+  elementId: string | undefined | null
+): string | undefined {
+  if (!elementId) return undefined;
+  return ELEMENT_ID_TO_OVERLAY_POSITION[elementId];
 }
 
 export function getCurrentDisplayType(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "noEmit": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,8 +8,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true
+    "forceConsistentCasingInFileNames": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
Accessible via query parameter `?cio_debug_session=true`.

Gif of initialization, detected polling, and then switch to SSE
<img width="520" height="470" alt="Screen Recording 2026-05-12 at 1 20 22 PM" src="https://github.com/user-attachments/assets/7c6dd012-39fe-4c72-a422-d2bc37c5c426" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new DOM-based debug overlay that hooks into message/route events and polls queue state, plus refactors route-rule matching into shared utility used in queue handling; these changes touch message delivery/visibility logic and could affect when messages are shown or filtered if the new matching behavior diverges.
> 
> **Overview**
> Adds an opt-in **debug overlay widget** (enabled via `?cio_debug_session=true`) that renders a fixed panel showing SDK config/connection mode, user token state, current route, and active/queued messages, with basic diagnostics (route-rule/target checks) and the ability to dismiss active messages.
> 
> Integrates the overlay by initializing it from `index.ts` and `Gist.setup()` (and exposing `Gist.setupDebugOverlay()`), and emits a new `routeChanged` event from `Gist.setCurrentRoute` so the overlay can refresh on navigation.
> 
> Refactors shared DOM/style helpers into `utilities/dom` (`el`, `injectStylesheet`, `appendToBody`) and reuses them in the preview bar, and centralizes route-rule evaluation into `message-utils.matchesRouteRule()` which is now used by `queue-manager.handleMessage()` (with tests updated to partially mock `message-utils`).
> 
> Exposes `getPollingIntervalSeconds()` from `queue-service` so the overlay can display the current polling interval.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6bca53eea07f04f81c9559cb060981699503739. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->