### PR TITLE
fix: clear polling throttle when SSE listener stops

### DIFF
--- a/src/managers/queue-manager.ts
+++ b/src/managers/queue-manager.ts
@@ -300,4 +300,5 @@ export function stopSSEListener(disconnectGlobally = false): void {
   log('Stopping SSE queue listener...');
   sseSource.close();
   sseSource = null;
+  clearKeyFromLocalStore(userQueueNextPullCheckLocalStoreName);
 }


### PR DESCRIPTION
`setUseSSEFlag` stores with 60-second TTL:
```
setKeyToLocalStore(
  userQueueUseSSELocalStoreName, 
  useSSE, 
  new Date(new Date().getTime() + 60000)
);
```
  
If SSE is enabled server-side and first poll sets flag to true but polling interval is 120 seconds, the flag expires before next poll tick checks it. The 1-second poll loop calls `pullMessagesFromQueue()`, but `settings.useSSE()` returns false because localStorage entry expired.

This fix is dkip polling throttle when SSE disconnects — clear `userQueueNextPullCheckLocalStoreName` in `stopSSEListener()` so polling resumes immediately.

