### PR TITLE
Added dark mode to the example app and fixed an issue with dark mode on the SDK

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -8,6 +8,22 @@
   </head>
   <body>
     <div class="inbox-header">
+      <button class="theme-toggle" id="themeToggle" onclick="toggleTheme()" aria-label="Toggle dark mode">
+        <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+        </svg>
+        <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="12" cy="12" r="5"></circle>
+          <line x1="12" y1="1" x2="12" y2="3"></line>
+          <line x1="12" y1="21" x2="12" y2="23"></line>
+          <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+          <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+          <line x1="1" y1="12" x2="3" y2="12"></line>
+          <line x1="21" y1="12" x2="23" y2="12"></line>
+          <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+          <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+        </svg>
+      </button>
       <div class="inbox-icon-container toggle-inbox">
         <svg class="inbox-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <polyline points="22 12 16 12 14 15 10 15 8 12 2 12"></polyline>
@@ -124,7 +140,7 @@
       <button id="offscreen-target" class="tooltip-target btn-green" onclick="showTooltipAt('#offscreen-target', 'top')" style="font-size: 16px; padding: 14px 28px;">
         I'm the offscreen target
       </button>
-      <p style="margin-top: 12px; color: #666; font-size: 14px;">This element starts below the fold. The SDK scrolled here because it predicted a valid tooltip placement.</p>
+      <p style="margin-top: 12px; color: var(--text-muted); font-size: 14px;">This element starts below the fold. The SDK scrolled here because it predicted a valid tooltip placement.</p>
     </div>
 
     <div class="config-form-sticky">
@@ -180,15 +196,41 @@
             <button type="button" class="button" onclick="resetConfig()">Reset to Defaults</button>
           </div>
         </form>
-        <div class="form-section" style="margin-top: 20px; border-top: 1px solid #ddd; padding-top: 20px;">
+        <div class="form-section" style="margin-top: 20px; border-top: 1px solid var(--border-light); padding-top: 20px;">
           <h4>Active Messages & Display Settings</h4>
           <div id="activeMessages" style="margin-top: 10px;">
-            <p style="color: #999; font-size: 14px;">No active messages</p>
+            <p style="color: var(--text-faint); font-size: 14px;">No active messages</p>
           </div>
           <button type="button" class="button" onclick="refreshActiveMessages()" style="margin-top: 10px;">Refresh Messages</button>
         </div>
       </div>
     </div>
+    <script>
+      function getPreferredTheme() {
+        var saved = localStorage.getItem('gistTheme');
+        if (saved) return saved;
+        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+      }
+
+      function applyTheme(theme) {
+        document.documentElement.setAttribute('data-theme', theme);
+      }
+
+      function toggleTheme() {
+        var current = document.documentElement.getAttribute('data-theme') || getPreferredTheme();
+        var next = current === 'dark' ? 'light' : 'dark';
+        localStorage.setItem('gistTheme', next);
+        applyTheme(next);
+      }
+
+      applyTheme(getPreferredTheme());
+
+      window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function(e) {
+        if (!localStorage.getItem('gistTheme')) {
+          applyTheme(e.matches ? 'dark' : 'light');
+        }
+      });
+    </script>
     <script src="settings.js"></script>
     <script src="../dist/gist.js"></script>
     <script type="text/javascript">
@@ -321,7 +363,7 @@
         const container = document.getElementById('activeMessages');
         
         if (!Gist.currentMessages || Gist.currentMessages.length === 0) {
-          container.innerHTML = '<p style="color: #999; font-size: 14px;">No active messages</p>';
+          container.innerHTML = '<p style="color: var(--text-faint); font-size: 14px;">No active messages</p>';
           return;
         }
 
@@ -329,23 +371,23 @@
         Gist.currentMessages.forEach((message, index) => {
           const displaySettings = message.displaySettings || {};
           const displaySettingsJson = JSON.stringify(displaySettings, null, 2);
-          
+
           html += `
-            <div style="border: 1px solid #ddd; border-radius: 4px; padding: 10px; margin-bottom: 10px; background: #f9f9f9;">
+            <div style="border: 1px solid var(--border-light); border-radius: 4px; padding: 10px; margin-bottom: 10px; background: var(--bg-surface-alt);">
               <div style="font-weight: bold; margin-bottom: 5px;">
                 Message: ${message.messageId || 'Unknown'}
-                <span style="font-size: 11px; color: #666; font-weight: normal;">(${message.instanceId})</span>
+                <span style="font-size: 11px; color: var(--text-muted); font-weight: normal;">(${message.instanceId})</span>
               </div>
               <div style="margin-bottom: 8px;">
                 <label style="display: block; font-size: 13px; font-weight: bold; margin-bottom: 4px;">Display Settings JSON:</label>
-                <textarea 
-                  id="displaySettings-${index}" 
-                  style="width: 100%; min-height: 100px; font-family: monospace; font-size: 12px; padding: 8px; border: 1px solid #ccc; border-radius: 3px;"
+                <textarea
+                  id="displaySettings-${index}"
+                  style="width: 100%; min-height: 100px; font-family: monospace; font-size: 12px; padding: 8px; border: 1px solid var(--border); border-radius: 3px; background: var(--input-bg); color: var(--input-color);"
                 >${displaySettingsJson}</textarea>
               </div>
-              <button 
-                class="button" 
-                onclick="updateMessageDisplaySettings(${index})" 
+              <button
+                class="button"
+                onclick="updateMessageDisplaySettings(${index})"
                 style="padding: 4px 12px; font-size: 12px;">
                 Save & Update
               </button>

--- a/examples/styles.css
+++ b/examples/styles.css
@@ -31,40 +31,6 @@
   color-scheme: light dark;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) {
-    --bg-page: #0f172a;
-    --bg-surface: #1e293b;
-    --bg-surface-alt: #1e293b;
-    --bg-inset: #162032;
-    --text-primary: #e2e8f0;
-    --text-secondary: #cbd5e1;
-    --text-muted: #94a3b8;
-    --text-faint: #64748b;
-    --text-heading: #7dd3fc;
-    --border: #334155;
-    --border-light: #334155;
-    --border-dashed: #475569;
-    --accent: #e76f51;
-    --accent-dark: #0f172a;
-    --accent-dark-hover: #1e293b;
-    --accent-teal: #2dd4bf;
-    --shadow: rgba(0,0,0,0.3);
-    --shadow-heavy: rgba(0,0,0,0.4);
-    --inbox-unopened-bg: #0f2942;
-    --inbox-body-color: #94a3b8;
-    --code-bg: #0f172a;
-    --code-alt-bg: #162032;
-    --scroll-btn-bg: #312e81;
-    --scroll-btn-color: #a5b4fc;
-    --input-bg: #0f172a;
-    --input-color: #e2e8f0;
-    --btn-secondary-bg: #475569;
-    --tooltip-log-bg: #0f172a;
-    --tooltip-log-border: #1e293b;
-  }
-}
-
 [data-theme="dark"] {
   --bg-page: #0f172a;
   --bg-surface: #1e293b;
@@ -110,7 +76,6 @@ body {
   padding-top: 40px;
   background-color: var(--bg-page);
   color: var(--text-primary);
-  color-scheme: light dark;
   transition: background-color 0.2s, color 0.2s;
 }
 

--- a/examples/styles.css
+++ b/examples/styles.css
@@ -1,3 +1,102 @@
+:root {
+  --bg-page: #ffffff;
+  --bg-surface: #ffffff;
+  --bg-surface-alt: #f5f5f5;
+  --bg-inset: #f8fafc;
+  --text-primary: #000000;
+  --text-secondary: #333333;
+  --text-muted: #666666;
+  --text-faint: #999999;
+  --text-heading: #264653;
+  --border: #e0e0e0;
+  --border-light: #dddddd;
+  --border-dashed: #cbd5e1;
+  --accent: #e76f51;
+  --accent-dark: #264653;
+  --accent-dark-hover: #1d3a44;
+  --accent-teal: #2a9d8f;
+  --shadow: rgba(0,0,0,0.1);
+  --shadow-heavy: rgba(0,0,0,0.15);
+  --inbox-unopened-bg: #f0f9ff;
+  --inbox-body-color: #555555;
+  --code-bg: #f5f5f5;
+  --code-alt-bg: #f0f0f5;
+  --scroll-btn-bg: #e0e7ff;
+  --scroll-btn-color: #4f46e5;
+  --input-bg: #ffffff;
+  --input-color: inherit;
+  --btn-secondary-bg: #888888;
+  --tooltip-log-bg: #1e293b;
+  --tooltip-log-border: #2d3748;
+  color-scheme: light dark;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --bg-page: #0f172a;
+    --bg-surface: #1e293b;
+    --bg-surface-alt: #1e293b;
+    --bg-inset: #162032;
+    --text-primary: #e2e8f0;
+    --text-secondary: #cbd5e1;
+    --text-muted: #94a3b8;
+    --text-faint: #64748b;
+    --text-heading: #7dd3fc;
+    --border: #334155;
+    --border-light: #334155;
+    --border-dashed: #475569;
+    --accent: #e76f51;
+    --accent-dark: #0f172a;
+    --accent-dark-hover: #1e293b;
+    --accent-teal: #2dd4bf;
+    --shadow: rgba(0,0,0,0.3);
+    --shadow-heavy: rgba(0,0,0,0.4);
+    --inbox-unopened-bg: #0f2942;
+    --inbox-body-color: #94a3b8;
+    --code-bg: #0f172a;
+    --code-alt-bg: #162032;
+    --scroll-btn-bg: #312e81;
+    --scroll-btn-color: #a5b4fc;
+    --input-bg: #0f172a;
+    --input-color: #e2e8f0;
+    --btn-secondary-bg: #475569;
+    --tooltip-log-bg: #0f172a;
+    --tooltip-log-border: #1e293b;
+  }
+}
+
+[data-theme="dark"] {
+  --bg-page: #0f172a;
+  --bg-surface: #1e293b;
+  --bg-surface-alt: #1e293b;
+  --bg-inset: #162032;
+  --text-primary: #e2e8f0;
+  --text-secondary: #cbd5e1;
+  --text-muted: #94a3b8;
+  --text-faint: #64748b;
+  --text-heading: #7dd3fc;
+  --border: #334155;
+  --border-light: #334155;
+  --border-dashed: #475569;
+  --accent: #e76f51;
+  --accent-dark: #0f172a;
+  --accent-dark-hover: #1e293b;
+  --accent-teal: #2dd4bf;
+  --shadow: rgba(0,0,0,0.3);
+  --shadow-heavy: rgba(0,0,0,0.4);
+  --inbox-unopened-bg: #0f2942;
+  --inbox-body-color: #94a3b8;
+  --code-bg: #0f172a;
+  --code-alt-bg: #162032;
+  --scroll-btn-bg: #312e81;
+  --scroll-btn-color: #a5b4fc;
+  --input-bg: #0f172a;
+  --input-color: #e2e8f0;
+  --btn-secondary-bg: #475569;
+  --tooltip-log-bg: #0f172a;
+  --tooltip-log-border: #1e293b;
+}
+
 html, body {
   padding: 0px;
   margin: 0px;
@@ -9,6 +108,10 @@ html, body {
 
 body {
   padding-top: 40px;
+  background-color: var(--bg-page);
+  color: var(--text-primary);
+  color-scheme: light dark;
+  transition: background-color 0.2s, color 0.2s;
 }
 
 .row {
@@ -21,6 +124,10 @@ body {
   gap: 16px;
 }
 
+.row.docs a {
+  color: var(--accent-teal);
+}
+
 h1 {
   font-size: 34px;
   line-height: 1.5;
@@ -30,7 +137,7 @@ h1 {
   display: flex;
   font-size: 15px;
   font-weight: bold;
-  background-color: #e76f51;
+  background-color: var(--accent);
   color: #fff;
   border-radius: 10px;
   min-width: 100px;
@@ -61,12 +168,12 @@ h1 {
 /* Inbox Header */
 .inbox-header {
   height: 40px;
-  background-color: #e76f51;
+  background-color: var(--accent);
   display: flex;
   align-items: center;
   justify-content: flex-end;
   padding: 0 16px;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  box-shadow: 0 2px 4px var(--shadow);
   position: fixed;
   top: 0;
   left: 0;
@@ -95,7 +202,7 @@ h1 {
   position: absolute;
   top: 2px;
   right: 2px;
-  background-color: #264653;
+  background-color: var(--accent-dark);
   color: white;
   border-radius: 10px;
   padding: 2px 6px;
@@ -105,6 +212,36 @@ h1 {
   text-align: center;
 }
 
+/* Theme Toggle */
+.theme-toggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 8px;
+  border-radius: 4px;
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.2s;
+  margin-right: 4px;
+}
+
+.theme-toggle:hover {
+  background-color: rgba(255,255,255,0.1);
+}
+
+.theme-toggle svg {
+  width: 20px;
+  height: 20px;
+}
+
+.theme-toggle .icon-sun { display: none; }
+.theme-toggle .icon-moon { display: block; }
+
+[data-theme="dark"] .theme-toggle .icon-sun { display: block; }
+[data-theme="dark"] .theme-toggle .icon-moon { display: none; }
+
 /* Inbox Panel */
 .inbox-panel {
   position: fixed;
@@ -113,8 +250,8 @@ h1 {
   width: 400px;
   max-width: 100%;
   max-height: calc(100vh - 40px);
-  background-color: white;
-  box-shadow: -2px 0 8px rgba(0,0,0,0.15);
+  background-color: var(--bg-surface);
+  box-shadow: -2px 0 8px var(--shadow-heavy);
   z-index: 999;
   overflow-y: auto;
   display: flex;
@@ -130,8 +267,8 @@ h1 {
   justify-content: space-between;
   align-items: center;
   padding: 16px;
-  border-bottom: 1px solid #e0e0e0;
-  background-color: #f5f5f5;
+  border-bottom: 1px solid var(--border);
+  background-color: var(--bg-surface-alt);
 }
 
 .inbox-panel-header h3 {
@@ -144,7 +281,7 @@ h1 {
   border: none;
   font-size: 28px;
   cursor: pointer;
-  color: #666;
+  color: var(--text-muted);
   padding: 0;
   width: 30px;
   height: 30px;
@@ -164,15 +301,15 @@ h1 {
 
 .no-messages {
   text-align: center;
-  color: #999;
+  color: var(--text-faint);
   padding: 32px 16px;
   font-size: 16px;
 }
 
 /* Inbox Message */
 .inbox-message {
-  background-color: #fff;
-  border: 1px solid #e0e0e0;
+  background-color: var(--bg-surface);
+  border: 1px solid var(--border);
   border-radius: 8px;
   padding: 16px;
   margin-bottom: 12px;
@@ -180,12 +317,12 @@ h1 {
 }
 
 .inbox-message:hover {
-  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  box-shadow: 0 2px 8px var(--shadow);
 }
 
 .inbox-message.unopened {
-  background-color: #f0f9ff;
-  border-color: #2a9d8f;
+  background-color: var(--inbox-unopened-bg);
+  border-color: var(--accent-teal);
 }
 
 .inbox-message-header {
@@ -197,18 +334,19 @@ h1 {
 
 .inbox-message-header strong {
   font-size: 16px;
-  color: #264653;
+  color: var(--text-heading);
 }
 
 .inbox-message-header p {
   font-size: 12px;
   font-style: italic;
+  color: var(--text-muted);
 }
 
 .unopened-dot {
   width: 8px;
   height: 8px;
-  background-color: #2a9d8f;
+  background-color: var(--accent-teal);
   border-radius: 50%;
   display: inline-block;
   margin-left: 8px;
@@ -216,13 +354,14 @@ h1 {
 
 .inbox-message-body {
   font-size: 14px;
-  color: #555;
+  color: var(--inbox-body-color);
   line-height: 1.5;
   margin-bottom: 12px;
 }
 
 .inbox-message-body pre {
-  background-color: #f5f5f5;
+  background-color: var(--code-bg);
+  color: var(--text-secondary);
   padding: 12px;
   border-radius: 4px;
   overflow-x: auto;
@@ -236,7 +375,7 @@ h1 {
 }
 
 .inbox-message-footer a {
-  color: #2a9d8f;
+  color: var(--accent-teal);
   text-decoration: none;
   font-size: 14px;
   font-weight: 600;
@@ -254,17 +393,17 @@ h1 {
 .inbox-message-actions button {
   padding: 6px 12px;
   font-size: 13px;
-  border: 1px solid #e0e0e0;
-  background-color: white;
-  color: #555;
+  border: 1px solid var(--border);
+  background-color: var(--bg-surface);
+  color: var(--inbox-body-color);
   border-radius: 4px;
   cursor: pointer;
   transition: all 0.2s;
 }
 
 .inbox-message-actions button:hover {
-  background-color: #f5f5f5;
-  border-color: #2a9d8f;
+  background-color: var(--bg-surface-alt);
+  border-color: var(--accent-teal);
 }
 
 @media (max-width: 800px) {
@@ -279,7 +418,7 @@ h1 {
   bottom: 0;
   left: 0;
   right: 0;
-  background-color: #264653;
+  background-color: var(--accent-dark);
   box-shadow: 0 -2px 8px rgba(0,0,0,0.2);
   z-index: 998;
 }
@@ -294,21 +433,21 @@ h1 {
   font-weight: 600;
   font-size: 14px;
   user-select: none;
-  background-color: #264653;
+  background-color: var(--accent-dark);
   transition: background-color 0.2s;
 }
 
 .config-form-header:hover {
-  background-color: #1d3a44;
+  background-color: var(--accent-dark-hover);
 }
 
 .config-form-content {
   display: none;
   max-height: 60vh;
   overflow-y: auto;
-  background-color: #f5f5f5;
+  background-color: var(--bg-surface-alt);
   padding: 16px;
-  border-top: 1px solid #1d3a44;
+  border-top: 1px solid var(--accent-dark-hover);
 }
 
 #configForm {
@@ -317,7 +456,7 @@ h1 {
 }
 
 .form-section {
-  background-color: white;
+  background-color: var(--bg-surface);
   padding: 16px;
   border-radius: 8px;
   margin-bottom: 16px;
@@ -325,9 +464,9 @@ h1 {
 
 .form-section h4 {
   margin: 0 0 16px 0;
-  color: #264653;
+  color: var(--text-heading);
   font-size: 16px;
-  border-bottom: 2px solid #e76f51;
+  border-bottom: 2px solid var(--accent);
   padding-bottom: 8px;
 }
 
@@ -341,7 +480,7 @@ h1 {
 .form-field label {
   min-width: 180px;
   font-size: 14px;
-  color: #333;
+  color: var(--text-secondary);
   font-weight: 500;
 }
 
@@ -349,16 +488,18 @@ h1 {
 .form-field select {
   flex: 1;
   padding: 8px 12px;
-  border: 1px solid #ddd;
+  border: 1px solid var(--border-light);
   border-radius: 4px;
   font-size: 14px;
   font-family: 'Courier New', monospace;
+  background-color: var(--input-bg);
+  color: var(--input-color);
 }
 
 .form-field input[type="text"]:focus,
 .form-field select:focus {
   outline: none;
-  border-color: #e76f51;
+  border-color: var(--accent);
 }
 
 .form-field input[type="checkbox"] {
@@ -386,12 +527,12 @@ h1 {
 }
 
 .form-actions .button.primary {
-  background-color: #e76f51;
+  background-color: var(--accent);
   color: white;
 }
 
 .form-actions .button:not(.primary) {
-  background-color: #888;
+  background-color: var(--btn-secondary-bg);
 }
 
 .form-actions .button:hover {
@@ -426,7 +567,7 @@ h1 {
 /* Tooltip Demo */
 .tooltip-demo {
   margin: 24px 16px;
-  background: #fff;
+  background: var(--bg-surface);
   border-radius: 12px;
   box-shadow: 0 2px 8px rgba(0,0,0,.06);
   padding: 28px;
@@ -435,8 +576,8 @@ h1 {
 .tooltip-demo h2 {
   font-size: 22px;
   margin-bottom: 24px;
-  color: #264653;
-  border-bottom: 2px solid #e76f51;
+  color: var(--text-heading);
+  border-bottom: 2px solid var(--accent);
   padding-bottom: 8px;
 }
 
@@ -447,18 +588,19 @@ h1 {
 .tooltip-section h3 {
   font-size: 16px;
   margin-bottom: 8px;
-  color: #333;
+  color: var(--text-secondary);
 }
 
 .tooltip-section p {
-  color: #666;
+  color: var(--text-muted);
   font-size: 14px;
   line-height: 1.6;
   margin-bottom: 12px;
 }
 
 .tooltip-section code {
-  background: #f0f0f5;
+  background: var(--code-alt-bg);
+  color: var(--text-secondary);
   padding: 2px 6px;
   border-radius: 4px;
   font-size: 13px;
@@ -500,16 +642,16 @@ h1 {
   align-items: center;
   justify-content: center;
   min-height: 120px;
-  background: #f8fafc;
-  border: 1px dashed #cbd5e1;
+  background: var(--bg-inset);
+  border: 1px dashed var(--border-dashed);
   border-radius: 10px;
 }
 
 .edge-demo-area {
   position: relative;
   min-height: 180px;
-  background: #f8fafc;
-  border: 1px dashed #cbd5e1;
+  background: var(--bg-inset);
+  border: 1px dashed var(--border-dashed);
   border-radius: 10px;
 }
 
@@ -525,14 +667,14 @@ h1 {
 .tooltip-scroll-container {
   max-height: 200px;
   overflow-y: auto;
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--border);
   border-radius: 8px;
   padding: 16px;
 }
 
 .tooltip-scroll-container .scroll-item {
   padding: 12px 16px;
-  border-bottom: 1px solid #f0f0f5;
+  border-bottom: 1px solid var(--border-light);
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -544,8 +686,8 @@ h1 {
 }
 
 .scroll-item-btn {
-  background: #e0e7ff;
-  color: #4f46e5;
+  background: var(--scroll-btn-bg);
+  color: var(--scroll-btn-color);
   border: none;
   padding: 4px 12px;
   border-radius: 6px;
@@ -555,7 +697,7 @@ h1 {
 }
 
 .tooltip-event-log {
-  background: #1e293b;
+  background: var(--tooltip-log-bg);
   border-radius: 10px;
   padding: 16px;
   min-height: 80px;
@@ -568,7 +710,7 @@ h1 {
 .tooltip-event-log .log-entry {
   color: #94a3b8;
   padding: 3px 0;
-  border-bottom: 1px solid #2d3748;
+  border-bottom: 1px solid var(--tooltip-log-border);
 }
 
 .tooltip-event-log .log-entry:last-child {

--- a/src/templates/embed.ts
+++ b/src/templates/embed.ts
@@ -44,6 +44,7 @@ export function embedHTMLTemplate(
                 height: 100%;
                 width: 100%;
                 border: none;
+                color-scheme: light only;
             }
             #x-gist-top.${elementId},
             #x-gist-bottom.${elementId},

--- a/src/templates/message.ts
+++ b/src/templates/message.ts
@@ -34,6 +34,7 @@ export function messageHTMLTemplate(
                 z-index: 9999999999;
                 left: 50%;
                 transform: translateX(-50%);
+                color-scheme: light only;
             }
             .gist-message.gist-visible {
                 opacity: 1;

--- a/src/templates/tooltip.ts
+++ b/src/templates/tooltip.ts
@@ -55,6 +55,7 @@ export function tooltipHTMLTemplate(
                 width: ${messageProperties.messageWidth}px;
                 border: none;
                 transition: height 0.1s ease-in-out;
+                color-scheme: light only;
             }
             ${scope}.gist-tooltip-arrow {
                 width: 0;


### PR DESCRIPTION
Added dark mode to the SDK's example app and fixed an issue effecting dark mode.

<img width="1577" height="1350" alt="Screenshot 2026-05-20 at 17 03 26" src="https://github.com/user-attachments/assets/25609a0e-8765-44fa-85e7-0653fd6a4c28" />

Addresses: [INAPP-14456](https://linear.app/customerio/issue/INAPP-14456/in-app-message-margin-renders-as-a-white-outline)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches SDK HTML templates for embedded/messages/tooltips by forcing `color-scheme: light only`, which can affect iframe rendering across all integrations. Example-app theming changes are low risk, but the template CSS change may have broad visual impact and should be verified in dark-mode host pages.
> 
> **Overview**
> Adds a **dark mode toggle** to the `examples` app (persisted in `localStorage` and synced with `prefers-color-scheme`) and refactors the demo UI to use CSS variables so all example components theme consistently.
> 
> Fixes an SDK dark-mode rendering issue by setting `color-scheme: light only` on the core iframe elements generated by `embed`, `message`, and `tooltip` templates, preventing host-page dark mode from altering message appearance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 226b465233f45e2f865218e0521bfd5ccedc12b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->