### PR TITLE
Add action config with button id to inbox action events

### DIFF
--- a/examples/inbox.js
+++ b/examples/inbox.js
@@ -80,3 +80,7 @@ refreshInboxMessages();
 window.Gist.events.on('messageInboxUpdated', async function(messages) {
     await refreshInboxMessages(messages);
 });
+
+window.Gist.events.on('inboxMessageAction', function(payload) {
+    console.log('[inboxMessageAction]', { action: payload.action, message: payload.message, actionConfig: payload.actionConfig });
+});

--- a/src/managers/inbox-component-manager.test.ts
+++ b/src/managers/inbox-component-manager.test.ts
@@ -309,6 +309,7 @@ describe('inbox-component-manager', () => {
       expect(Gist.events.dispatch).toHaveBeenCalledWith('inboxMessageAction', {
         message: expect.objectContaining({ queueId: 'q1' }),
         action: 'clicked',
+        actionConfig: expect.objectContaining({ behavior: 'dismiss' }),
       });
     });
 
@@ -372,6 +373,7 @@ describe('inbox-component-manager', () => {
       expect(Gist.events.dispatch).toHaveBeenCalledWith('inboxMessageAction', {
         message: expect.objectContaining({ queueId: 'q1' }),
         action: 'clicked',
+        actionConfig: expect.objectContaining({ behavior: 'performAction' }),
       });
     });
 

--- a/src/managers/inbox-component-manager.ts
+++ b/src/managers/inbox-component-manager.ts
@@ -220,7 +220,7 @@ function renderPanel(pattern: InboxPattern, messages: InboxMessage[]): void {
     jist.onAction = (event) => {
       log(`Inbox action: ${event.name}`);
 
-      const actionConfig = parseActionConfig(event.data);
+      const actionConfig = parseActionConfig(event.name, event.data);
       if (!actionConfig) return;
 
       handleInboxAction(message, actionConfig);
@@ -292,10 +292,11 @@ function handleInboxAction(message: InboxMessage, config: InboxActionConfig): vo
   Gist.events.dispatch('inboxMessageAction', {
     message,
     action: 'clicked',
+    actionConfig: config,
   });
 }
 
-function parseActionConfig(data: unknown): InboxActionConfig | null {
+function parseActionConfig(id: string, data: unknown): InboxActionConfig | null {
   if (!data || typeof data !== 'object') return null;
 
   const obj = data as Record<string, unknown>;
@@ -312,6 +313,7 @@ function parseActionConfig(data: unknown): InboxActionConfig | null {
     return null;
 
   return {
+    id,
     behavior: obj.behavior as InboxActionBehavior,
     action: typeof obj.action === 'string' ? obj.action : undefined,
     name: typeof obj.name === 'string' ? obj.name : undefined,

--- a/src/types.ts
+++ b/src/types.ts
@@ -134,6 +134,7 @@ export interface ResolvedMessageProperties {
 export type InboxActionBehavior = 'openUrl' | 'dismiss' | 'openDeeplink' | 'performAction';
 
 export interface InboxActionConfig {
+  id: string;
   behavior: InboxActionBehavior;
   action?: string;
   name?: string;


### PR DESCRIPTION
## Summary

- Includes `actionConfig` (with button `id`, `behavior`, `action`, `name`, `dismiss`, `newTab`) in the `inboxMessageAction` event payload when a button is clicked
- Adds `id` field to `InboxActionConfig` populated from the Jist button name
- Adds debug logging for `inboxMessageAction` events in the example app

## Test plan

- [x] Click an inbox message button and verify the `inboxMessageAction` event includes `actionConfig` with the correct `id` and `behavior`
- [x] Verify opened/unopened events still dispatch without `actionConfig` (backwards compatible)

---

> [!NOTE]
> **Low Risk**
> Additive event payload and type field for click actions only; existing listeners that ignore extra fields remain compatible.
> 
> **Overview**
> **`inboxMessageAction` now carries full button context** when a Jist inbox control is clicked: the event payload adds **`actionConfig`**, including a new **`id`** on `InboxActionConfig` set from the Jist action **`event.name`** (button identifier) plus existing fields (`behavior`, `action`, `name`, `dismiss`, `newTab`).
> 
> `parseActionConfig` takes the action id as its first argument; `handleInboxAction` passes the parsed config through on dispatch. Tests assert `actionConfig` for dismiss and performAction flows. The example app logs `inboxMessageAction` with `actionConfig` for debugging.
> 
> This is an **additive** public event shape change for click handlers; open/unopened dispatches are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4f443e90cc4f70350a735a0f0a8e1605172ff39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->