### PR TITLE
Track dismissed event for inbox messages

### DIFF
--- a/src/managers/inbox-message-manager.test.ts
+++ b/src/managers/inbox-message-manager.test.ts
@@ -135,7 +135,7 @@ describe('inbox-message-manager', () => {
     );
   });
 
-  it('removeInboxMessage logs view, removes from store, dispatches event', async () => {
+  it('removeInboxMessage logs view, removes from store, dispatches dismissed and updated events', async () => {
     vi.mocked(logUserMessageView).mockResolvedValue({ status: 200 } as never);
     const stored: InboxMessage[] = [
       { messageId: 'm1', queueId: 'q1' },
@@ -152,6 +152,10 @@ describe('inbox-message-manager', () => {
       [{ messageId: 'm2', queueId: 'q2' }],
       expect.any(Date)
     );
+    expect(Gist.events.dispatch).toHaveBeenCalledWith('inboxMessageAction', {
+      message: { messageId: 'm1', queueId: 'q1' },
+      action: 'dismissed',
+    });
     expect(Gist.events.dispatch).toHaveBeenCalledWith('messageInboxUpdated', afterRemove);
   });
 
@@ -167,6 +171,10 @@ describe('inbox-message-manager', () => {
       [],
       expect.any(Date)
     );
+    expect(Gist.events.dispatch).toHaveBeenCalledWith('inboxMessageAction', {
+      message: { messageId: 'm1', queueId: 'q1' },
+      action: 'dismissed',
+    });
     expect(Gist.events.dispatch).toHaveBeenCalledWith('messageInboxUpdated', []);
   });
 });

--- a/src/managers/inbox-message-manager.ts
+++ b/src/managers/inbox-message-manager.ts
@@ -104,11 +104,19 @@ export async function removeInboxMessage(queueId: string): Promise<void> {
   if (!inboxLocalStoreName) return;
 
   const messages = await getInboxMessagesFromLocalStore();
+  const removedMessage = messages.find((message) => message.queueId === queueId) ?? null;
   const filteredMessages = messages.filter((message) => message.queueId !== queueId);
 
   const expiryDate = new Date();
   expiryDate.setMinutes(expiryDate.getMinutes() + inboxMessagesLocalStoreCacheInMinutes);
   setKeyToLocalStore(inboxLocalStoreName, filteredMessages, expiryDate);
+
+  if (removedMessage) {
+    Gist.events.dispatch(inboxMessageEventName, {
+      message: removedMessage,
+      action: 'dismissed',
+    });
+  }
 
   Gist.events.dispatch(messageInboxUpdatedEventName, await getInboxMessagesFromLocalStore());
 


### PR DESCRIPTION
## Summary
- Dispatch an `inboxMessageAction` event with `action: 'dismissed'` when an inbox message is removed via `removeInboxMessage`, completing the set alongside the existing `opened` and `clicked` events.
- The dismissed message is captured before removal so it can be included in the event payload, matching the shape of the other inbox action events.

## Test plan
- [x] Existing tests updated to verify the `dismissed` event is dispatched on removal
- [x] Verified event fires even when the `logUserMessageView` API call fails
- [x] Full test suite passes (501 tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral addition (client event only) in inbox local-store removal; no auth or server contract changes beyond existing logging.
> 
> **Overview**
> When an inbox message is removed via **`removeInboxMessage`**, the SDK now emits an **`inboxMessageAction`** event with **`action: 'dismissed'`**, using the message captured before it is filtered out of local storage—aligned with existing **`opened`** / **`clicked`** payloads.
> 
> Tests assert this event is dispatched on successful removal and still fires when **`logUserMessageView`** fails, alongside the existing **`messageInboxUpdated`** dispatch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb39e4d9b1db9487597785533b7ebc030c8eb546. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->