### PR TITLE
Include actionConfig in inboxMessageAction clicked event

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -274,7 +274,7 @@
       });
 
       Gist.events.on("inboxMessageAction", params => {
-        console.log(`onInboxMessageAction, Action: ${params.action}, Inbox Message:`, params.message);
+        console.log(`onInboxMessageAction, Action: ${params.action}, Inbox Message:`, params.message, params.actionConfig);
       });
 
       function showHTMLMessage() {

--- a/src/managers/inbox-component-manager.test.ts
+++ b/src/managers/inbox-component-manager.test.ts
@@ -309,6 +309,7 @@ describe('inbox-component-manager', () => {
       expect(Gist.events.dispatch).toHaveBeenCalledWith('inboxMessageAction', {
         message: expect.objectContaining({ queueId: 'q1' }),
         action: 'clicked',
+        actionConfig: expect.objectContaining({ behavior: 'dismiss' }),
       });
     });
 
@@ -372,6 +373,7 @@ describe('inbox-component-manager', () => {
       expect(Gist.events.dispatch).toHaveBeenCalledWith('inboxMessageAction', {
         message: expect.objectContaining({ queueId: 'q1' }),
         action: 'clicked',
+        actionConfig: expect.objectContaining({ behavior: 'performAction' }),
       });
     });
 

--- a/src/managers/inbox-component-manager.ts
+++ b/src/managers/inbox-component-manager.ts
@@ -292,6 +292,7 @@ function handleInboxAction(message: InboxMessage, config: InboxActionConfig): vo
   Gist.events.dispatch('inboxMessageAction', {
     message,
     action: 'clicked',
+    actionConfig: config,
   });
 }
 


### PR DESCRIPTION
## Summary
- Includes the parsed `actionConfig` (behavior, action, name, dismiss, newTab) in the `inboxMessageAction` event payload when an inbox message action is clicked
- Updates the example in `index.html` to log the new `actionConfig` field
- Updates tests to assert `actionConfig` is present in the dispatched event

## Test plan
- [x] Verify `inboxMessageAction` event listeners receive `actionConfig` with the correct behavior and properties when an inbox action is clicked

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive event payload field only; no change to dismiss, URL, or navigation behavior.
> 
> **Overview**
> The **`inboxMessageAction`** event payload for **clicked** inbox actions now includes **`actionConfig`**: the parsed config the SDK already used (`behavior`, `action`, `name`, `dismiss`, `newTab`), so integrators can react without re-parsing template action data.
> 
> The example page logs the new field; unit tests assert **`actionConfig`** on dismiss and performAction dispatches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29b3fc089ac90b28e7ed47b6e4031d290d19e65d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->