### PR TITLE
Update uuid to v14 to fix moderate vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,10 @@
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@customerio/jist": "^0.1.6",
-        "uuid": "^8.3.2"
+        "uuid": "^14.0.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.13.0",
-        "@types/uuid": "^10.0.0",
         "eslint": "^9.13.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.5",
@@ -1317,13 +1316,6 @@
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
-    },
-    "node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.60.0",
@@ -6929,13 +6921,16 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-license": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   "license": "SEE LICENSE IN LICENSE",
   "devDependencies": {
     "@eslint/js": "^9.13.0",
-    "@types/uuid": "^10.0.0",
     "eslint": "^9.13.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.5",
@@ -52,7 +51,7 @@
   },
   "dependencies": {
     "@customerio/jist": "^0.1.6",
-    "uuid": "^8.3.2"
+    "uuid": "^14.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Updates `uuid` from `8.3.2` to `14.0.0` to resolve moderate severity vulnerability [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq) (missing buffer bounds check in v3/v5/v6)
- Removes `@types/uuid` since uuid v14 ships its own TypeScript types
- No code changes required — our usage is limited to `v4` which is unchanged across major versions

Addresses: [INAPP-14471](https://linear.app/customerio/issue/INAPP-14471/update-vulnerable-uuid-dependency-in-customerio-gist-web-package)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only change with continued v4 usage; no auth, data, or logic changes in the diff.
> 
> **Overview**
> Bumps **`uuid`** from **8.3.2** to **14.0.0** to address a moderate security advisory on older releases, and drops **`@types/uuid`** because v14 ships built-in TypeScript types.
> 
> There are **no application source changes** in the diff; runtime behavior for existing **`v4`** ID generation should stay the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b5100d50bac3851b659fb30a54725acfea74b6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->