### PR TITLE
feat: Dismiss modal messages with ESC key when exitClick is enabled

### DIFF
--- a/src/managers/message-component-manager.test.ts
+++ b/src/managers/message-component-manager.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   showEmbedComponent,
   hideEmbedComponent,
   elementHasHeight,
   resizeComponent,
+  showOverlayComponent,
   removeOverlayComponent,
   changeOverlayTitle,
   loadTooltipComponent,
@@ -139,6 +140,95 @@ describe('message-component-manager', () => {
     removeOverlayComponent();
 
     expect(document.getElementById('gist-embed-message')).toBeNull();
+  });
+
+  describe('showOverlayComponent dismiss listeners', () => {
+    const resolvedProperties = {
+      isEmbedded: false,
+      elementId: '',
+      hasRouteRule: false,
+      routeRule: '',
+      position: '',
+      hasPosition: false,
+      tooltipPosition: '',
+      hasTooltipPosition: false,
+      tooltipArrowColor: '#fff',
+      shouldScale: false,
+      campaignId: null,
+      messageWidth: 414,
+      overlayColor: '#00000033',
+      persistent: false,
+      exitClick: false,
+      hasCustomWidth: false,
+    };
+
+    function setupOverlay(exitClick: boolean): GistMessage {
+      vi.mocked(resolveMessageProperties).mockReturnValue({ ...resolvedProperties, exitClick });
+      document.body.innerHTML =
+        '<div id="gist-embed-message"><div id="gist-overlay"><div class="gist-message"></div></div></div>';
+      const message: GistMessage = { messageId: 'msg-1', instanceId: 'inst-1' };
+      showOverlayComponent(message);
+      return message;
+    }
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      removeOverlayComponent();
+      vi.useRealTimers();
+    });
+
+    it('dismisses the message on overlay click when exitClick is enabled', () => {
+      setupOverlay(true);
+      vi.advanceTimersByTime(1000);
+
+      document.getElementById('gist-overlay')?.dispatchEvent(new Event('click'));
+
+      expect(mockGist.dismissMessage).toHaveBeenCalledWith('inst-1');
+    });
+
+    it('does not dismiss on overlay click before the arming delay has elapsed', () => {
+      setupOverlay(true);
+
+      document.getElementById('gist-overlay')?.dispatchEvent(new Event('click'));
+
+      expect(mockGist.dismissMessage).not.toHaveBeenCalled();
+    });
+
+    it('dismisses the message on Escape key immediately when exitClick is enabled', () => {
+      setupOverlay(true);
+
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+
+      expect(mockGist.dismissMessage).toHaveBeenCalledWith('inst-1');
+    });
+
+    it('does not dismiss on other keys when exitClick is enabled', () => {
+      setupOverlay(true);
+
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+
+      expect(mockGist.dismissMessage).not.toHaveBeenCalled();
+    });
+
+    it('does not dismiss on Escape key when exitClick is disabled', () => {
+      setupOverlay(false);
+
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+
+      expect(mockGist.dismissMessage).not.toHaveBeenCalled();
+    });
+
+    it('stops listening for Escape after the overlay is removed', () => {
+      setupOverlay(true);
+
+      removeOverlayComponent();
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+
+      expect(mockGist.dismissMessage).not.toHaveBeenCalled();
+    });
   });
 
   it('changeOverlayTitle sets the iframe title attribute', () => {

--- a/src/managers/message-component-manager.ts
+++ b/src/managers/message-component-manager.ts
@@ -216,6 +216,7 @@ export function loadOverlayComponent(
   options: MessageOptions,
   stepName: string | null = null
 ): void {
+  removeEscapeKeyListener();
   document.querySelectorAll('#gist-embed-message').forEach((el) => {
     el.parentNode?.removeChild(el);
   });
@@ -293,6 +294,7 @@ export function showOverlayComponent(message: GistMessage): void {
     }
     setTimeout(showMessage, 100);
     if (messageProperties.exitClick) {
+      addEscapeKeyListener(message.instanceId ?? '');
       setTimeout(() => addDismissListener(message.instanceId ?? ''), 1000);
     }
   } else {
@@ -309,6 +311,25 @@ function addDismissListener(instanceId: string): void {
   }
 }
 
+let escapeKeyListener: ((event: KeyboardEvent) => void) | null = null;
+
+function addEscapeKeyListener(instanceId: string): void {
+  removeEscapeKeyListener();
+  escapeKeyListener = (event: KeyboardEvent) => {
+    if (event.key === 'Escape') {
+      Gist.dismissMessage(instanceId);
+    }
+  };
+  document.addEventListener('keydown', escapeKeyListener);
+}
+
+function removeEscapeKeyListener(): void {
+  if (escapeKeyListener) {
+    document.removeEventListener('keydown', escapeKeyListener);
+    escapeKeyListener = null;
+  }
+}
+
 export async function hideOverlayComponent(): Promise<void> {
   const message = document.querySelector('.gist-message');
   if (message) {
@@ -319,6 +340,7 @@ export async function hideOverlayComponent(): Promise<void> {
 }
 
 export function removeOverlayComponent(): void {
+  removeEscapeKeyListener();
   const mainMessageElement = document.querySelector('#gist-embed-message');
   if (mainMessageElement) {
     mainMessageElement.parentNode?.removeChild(mainMessageElement);


### PR DESCRIPTION
## Summary

Modal messages with `exitClick` enabled can now also be dismissed by pressing the ESC key.

- A `keydown` listener for `Escape` is attached to the parent document as soon as the overlay is shown. Unlike click-to-dismiss — which keeps its 1-second arming delay so the click that triggered the message can't instantly dismiss it — the ESC handler is active immediately.
- The document-level listener is cleaned up in `removeOverlayComponent()` (the teardown path both hide and dismiss funnel through) and when a new overlay replaces an existing one, so no stale listener can outlive its modal.
- ESC does nothing when `exitClick` is disabled, matching the existing click behavior.

Note: the listener lives on the parent document, so ESC works whenever the host page has focus. Key events while focus is inside the message iframe would need forwarding from the renderer, which is out of scope here.

## Testing

Added tests covering: ESC dismisses immediately when `exitClick` is enabled, other keys don't dismiss, ESC does nothing when `exitClick` is disabled, the listener is removed on overlay teardown, and the existing click-to-dismiss behavior (including its arming delay), which previously had no coverage.

Linear: [INAPP-14486](https://linear.app/customerio/issue/INAPP-14486/in-app-messages-do-not-close-with-esc-key)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UX change gated on exitClick with explicit listener teardown; no auth or data-path changes.
> 
> **Overview**
> Modal overlays with **`exitClick`** can now be dismissed with **Escape** on the host document, in addition to the existing overlay click behavior.
> 
> When **`exitClick`** is on, a document **`keydown`** listener calls **`Gist.dismissMessage`** for **Escape** as soon as the overlay is shown—**without** the 1-second delay used for click-to-dismiss. Escape is ignored when **`exitClick`** is off. The listener is removed when the overlay is torn down (**`removeOverlayComponent`**) and when a new overlay is loaded (**`loadOverlayComponent`**), so it cannot outlive the modal.
> 
> Tests were added for Escape dismiss, non-Escape keys, **`exitClick`** off, listener cleanup after removal, and the existing click dismiss path including the arming delay.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 715e6f597e2549a0238b8e901fb88798a71a52cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->