### PR TITLE
fix: Defer route-ruled messages until setCurrentRoute fires on cold-load

### DIFF
--- a/src/gist.test.ts
+++ b/src/gist.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { GistConfig, GistMessage, DisplaySettings } from './types';
 import type { InboxMessage } from './managers/inbox-message-manager';
 
@@ -105,6 +105,7 @@ function resetGist() {
   Gist.currentMessages = [];
   Gist.overlayInstanceId = null;
   Gist.currentRoute = null;
+  Gist.routeInitialized = false;
   Gist.isDocumentVisible = true;
   Gist.config = undefined as unknown as GistConfig;
   Gist.events = undefined as unknown as typeof Gist.events;
@@ -253,43 +254,37 @@ describe('Gist', () => {
       expect(Gist.isDocumentVisible).toBe(true);
     });
 
-    describe('DOMContentLoaded queue recheck', () => {
-      function simulateReadyState(state: string) {
-        Object.defineProperty(document, 'readyState', {
-          value: state,
-          writable: true,
-          configurable: true,
-        });
-      }
+    it('sets routeInitialized to false', async () => {
+      await Gist.setup(baseConfig());
+      expect(Gist.routeInitialized).toBe(false);
+    });
 
-      afterEach(() => {
-        simulateReadyState('complete');
-      });
+    it('sets routeInitialized to true after grace period', async () => {
+      vi.useFakeTimers();
+      await Gist.setup(baseConfig());
 
-      it('registers listener when page is loading', async () => {
-        simulateReadyState('loading');
-        const addSpy = vi.spyOn(document, 'addEventListener');
+      expect(Gist.routeInitialized).toBe(false);
+      vi.advanceTimersByTime(2000);
+      expect(Gist.routeInitialized).toBe(true);
+      expect(checkMessageQueue).toHaveBeenCalled();
 
-        await Gist.setup(baseConfig());
+      vi.useRealTimers();
+    });
 
-        expect(addSpy).toHaveBeenCalledWith('DOMContentLoaded', expect.any(Function), {
-          once: true,
-        });
-        addSpy.mockRestore();
-      });
+    it('does not override routeInitialized if setCurrentRoute was called before grace period', async () => {
+      vi.useFakeTimers();
+      await Gist.setup(baseConfig());
+      vi.mocked(checkMessageQueue).mockClear();
 
-      it('skips listener when page is not loading', async () => {
-        simulateReadyState('complete');
-        const addSpy = vi.spyOn(document, 'addEventListener');
+      await Gist.setCurrentRoute('/cart');
+      expect(Gist.routeInitialized).toBe(true);
 
-        await Gist.setup(baseConfig());
+      vi.mocked(checkMessageQueue).mockClear();
+      vi.advanceTimersByTime(2000);
+      // Timer fires but is a no-op since routeInitialized is already true
+      expect(checkMessageQueue).not.toHaveBeenCalled();
 
-        const domContentLoadedCalls = addSpy.mock.calls.filter(
-          ([event]) => event === 'DOMContentLoaded'
-        );
-        expect(domContentLoadedCalls).toHaveLength(0);
-        addSpy.mockRestore();
-      });
+      vi.useRealTimers();
     });
   });
 
@@ -304,6 +299,15 @@ describe('Gist', () => {
       expect(Gist.currentRoute).toBe('/home');
       expect(checkCurrentMessagesAfterRouteChange).toHaveBeenCalled();
       expect(checkMessageQueue).toHaveBeenCalled();
+    });
+
+    it('sets routeInitialized to true', async () => {
+      await Gist.setup(baseConfig());
+      expect(Gist.routeInitialized).toBe(false);
+
+      await Gist.setCurrentRoute('/home');
+
+      expect(Gist.routeInitialized).toBe(true);
     });
   });
 

--- a/src/gist.ts
+++ b/src/gist.ts
@@ -40,6 +40,8 @@ import { destroyInbox } from './managers/inbox-component-manager';
 import type { GistConfig, GistMessage, DisplaySettings, ColorScheme } from './types';
 import type { InboxMessage } from './managers/inbox-message-manager';
 
+const ROUTE_INIT_GRACE_PERIOD_MS = 2000;
+
 export default class Gist {
   static events: EventEmitter;
   static config: GistConfig;
@@ -47,6 +49,7 @@ export default class Gist {
   static currentMessages: GistMessage[];
   static overlayInstanceId: string | null;
   static currentRoute: string | null;
+  static routeInitialized: boolean;
   static isDocumentVisible: boolean;
 
   static async setup(config: GistConfig): Promise<void> {
@@ -69,6 +72,7 @@ export default class Gist {
     clearAllTooltipHandles();
     this.overlayInstanceId = null;
     this.currentRoute = null;
+    this.routeInitialized = false;
     this.isDocumentVisible = true;
     this.config.isPreviewSession = setupPreview();
     setupDebugOverlay();
@@ -90,9 +94,12 @@ export default class Gist {
 
     await startQueueListener();
 
-    if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', () => void checkMessageQueue(), { once: true });
-    }
+    setTimeout(() => {
+      if (!this.routeInitialized) {
+        this.routeInitialized = true;
+        void checkMessageQueue();
+      }
+    }, ROUTE_INIT_GRACE_PERIOD_MS);
 
     document.addEventListener(
       'visibilitychange',
@@ -113,6 +120,7 @@ export default class Gist {
   }
 
   static async setCurrentRoute(route: string): Promise<void> {
+    this.routeInitialized = true;
     this.currentRoute = route;
     log(`Current route set to: ${route}`);
     await checkCurrentMessagesAfterRouteChange();

--- a/src/managers/queue-manager.test.ts
+++ b/src/managers/queue-manager.test.ts
@@ -104,6 +104,7 @@ vi.mock('../utilities/dom', () => ({
 vi.mock('../gist', () => ({
   default: {
     currentRoute: null,
+    routeInitialized: true,
     isDocumentVisible: true,
     currentMessages: [],
     overlayInstanceId: null,
@@ -716,27 +717,19 @@ describe('queue-manager', () => {
       });
     });
 
-    // --- Race condition: page still loading ---
+    // --- Race condition: route not yet initialized ---
 
-    describe('defers messages while page is loading', () => {
-      function simulateReadyState(state: string) {
-        Object.defineProperty(document, 'readyState', {
-          value: state,
-          writable: true,
-          configurable: true,
-        });
-      }
-
+    describe('defers messages before route initialization', () => {
       beforeEach(() => {
         (Gist as unknown as Record<string, unknown>).currentRoute = null;
+        (Gist as unknown as Record<string, unknown>).routeInitialized = false;
       });
 
       afterEach(() => {
-        simulateReadyState('complete');
+        (Gist as unknown as Record<string, unknown>).routeInitialized = true;
       });
 
-      it('defers message with route rule when page is loading and route is not set', async () => {
-        simulateReadyState('loading');
+      it('defers message with route rule when route is not yet initialized', async () => {
         withRouteRule('^(.*\\/dashboard.*)$');
         navigateTo('/dashboard');
 
@@ -746,29 +739,27 @@ describe('queue-manager', () => {
         expect(showMessage).not.toHaveBeenCalled();
       });
 
-      it('evaluates immediately when currentRoute is set even during loading', async () => {
-        simulateReadyState('loading');
-        withRouteRule('^(.*\\/dashboard.*)$');
-        navigateTo('/dashboard');
-        (Gist as unknown as Record<string, unknown>).currentRoute = '/dashboard';
-
-        await handleMessage(message);
-
-        expect(showMessage).toHaveBeenCalledWith(message);
-      });
-
-      it('evaluates once DOM is interactive even if currentRoute is null', async () => {
-        simulateReadyState('interactive');
+      it('defers even when readyState is interactive (cold-load race)', async () => {
+        Object.defineProperty(document, 'readyState', {
+          value: 'interactive',
+          writable: true,
+          configurable: true,
+        });
         withRouteRule('^(.*\\/dashboard.*)$');
         navigateTo('/dashboard');
 
-        await handleMessage(message);
+        const result = await handleMessage(message);
 
-        expect(showMessage).toHaveBeenCalledWith(message);
+        expect(result).toBe(false);
+        expect(showMessage).not.toHaveBeenCalled();
+        Object.defineProperty(document, 'readyState', {
+          value: 'complete',
+          writable: true,
+          configurable: true,
+        });
       });
 
-      it('defers exclusion rule evaluation when page is loading', async () => {
-        simulateReadyState('loading');
+      it('defers exclusion rule evaluation before route initialization', async () => {
         const origin = window.location.origin;
         const escaped = origin.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
         withRouteRule(`^(?!.*(?:(^${escaped}\\/dashboard\\/$))).*$`);
@@ -780,16 +771,47 @@ describe('queue-manager', () => {
         expect(showMessage).not.toHaveBeenCalled();
       });
 
-      it('shows message without route rule even when page is loading', async () => {
-        simulateReadyState('loading');
+      it('evaluates immediately when currentRoute is set even before routeInitialized', async () => {
+        withRouteRule('^(.*\\/dashboard.*)$');
+        navigateTo('/dashboard');
+        (Gist as unknown as Record<string, unknown>).currentRoute = '/dashboard';
+
+        await handleMessage(message);
+
+        expect(showMessage).toHaveBeenCalledWith(message);
+      });
+
+      it('shows message without route rule even before route initialization', async () => {
         vi.mocked(resolveMessageProperties).mockReturnValue(defaultProperties);
         navigateTo('/dashboard');
 
         const result = await handleMessage(message);
 
-        // Not deferred (no route rule), but showMessage mock returns null
         expect(result).toBe(false);
         expect(showMessage).toHaveBeenCalledWith(message);
+      });
+
+      it('evaluates against pathname after route initialization grace period', async () => {
+        (Gist as unknown as Record<string, unknown>).routeInitialized = true;
+        withRouteRule('^(.*\\/dashboard.*)$');
+        navigateTo('/dashboard');
+
+        await handleMessage(message);
+
+        expect(showMessage).toHaveBeenCalledWith(message);
+      });
+
+      it('defers localized URL that would bypass exclusion rule on cold-load', async () => {
+        // Simulates: exclusion rule "does not contain /cart", localized URL /nl/winkelwagen/
+        // Before routeInitialized, this must be deferred — the customer will call
+        // setCurrentRoute("/cart") momentarily, which would correctly block the message
+        withRouteRule('^(?!.*\\/cart).*$');
+        navigateTo('/nl/winkelwagen/');
+
+        const result = await handleMessage(message);
+
+        expect(result).toBe(false);
+        expect(showMessage).not.toHaveBeenCalled();
       });
     });
   });

--- a/src/managers/queue-manager.ts
+++ b/src/managers/queue-manager.ts
@@ -91,8 +91,8 @@ export async function checkCurrentMessagesAfterRouteChange(): Promise<void> {
 export async function handleMessage(message: GistMessage): Promise<boolean> {
   let messageProperties = resolveMessageProperties(message);
   if (messageProperties.hasRouteRule) {
-    if (Gist.currentRoute == null && document.readyState === 'loading') {
-      log(`Deferring message ${message.queueId}, page not fully loaded`);
+    if (Gist.currentRoute == null && !Gist.routeInitialized) {
+      log(`Deferring message ${message.queueId}, route not yet initialized`);
       return false;
     }
 


### PR DESCRIPTION
## Summary

Fixes a race condition where web in-app messages with page exclusion rules (e.g. "does not contain /cart") appear on excluded pages when a user hard-refreshes or lands directly on a localized URL (e.g. `/nl/winkelwagen/`).

- The previous fix (PR #149) guarded route-rule evaluation with `document.readyState === 'loading'`, but by the time `checkMessageQueue` runs asynchronously (via polling, SSE, or `setUserToken`), `readyState` is already `'interactive'` or `'complete'` — so the guard never triggers
- Replace the `readyState`-based guard with a `routeInitialized` flag that stays `false` until `setCurrentRoute()` is called, with a 2-second grace period fallback for sites that never call `setCurrentRoute()`
- Remove the now-redundant `DOMContentLoaded` handler that was part of the previous fix

Resolves [INAPP-14479](https://linear.app/customerio/issue/INAPP-14479)

## Test plan

- [ ] Verify messages with route exclusion rules are deferred on cold-load until `setCurrentRoute()` fires
- [ ] Verify messages appear correctly after `setCurrentRoute()` is called
- [ ] Verify messages with route rules still show after the 2s grace period if `setCurrentRoute()` is never called
- [ ] Verify messages without route rules are unaffected (shown immediately)
- [ ] Verify SPA navigation continues to work correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when route-targeted in-app messages are shown on first load; wrong timing could briefly hide messages or show them before canonical route is set, though grace period and setCurrentRoute preserve backward compatibility.
> 
> **Overview**
> Fixes a **cold-load race** where in-app messages with **page route rules** (especially exclusions like “does not contain `/cart`”) could show on the wrong localized URL before the host app calls `setCurrentRoute`.
> 
> **`Gist.routeInitialized`** starts `false` on setup. **`setCurrentRoute`** sets it to `true` immediately. **`handleMessage`** now defers route-rule evaluation when `currentRoute` is still `null` and **`routeInitialized` is false**, instead of relying on `document.readyState === 'loading'` (which often is already `interactive`/`complete` when the queue runs async).
> 
> Setup **drops the `DOMContentLoaded` queue recheck** and adds a **2s grace-period timer** that sets `routeInitialized` and runs `checkMessageQueue` only if the host never called `setCurrentRoute`. Messages **without** route rules are unchanged and can still show immediately.
> 
> Tests cover the grace timer, early `setCurrentRoute`, interactive `readyState`, and localized exclusion bypass cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cdf559755c971e6fb34235dde7b7c983c81a5f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->